### PR TITLE
bears/general: Add InvalidLinkBear

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -1,0 +1,75 @@
+import re
+import requests
+
+from coalib.results.Diff import Diff
+from coalib.bears.LocalBear import LocalBear
+from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
+from coalib.results.Result import Result
+
+
+class InvalidLinkBear(LocalBear):
+
+    @classmethod
+    def check_prerequisites(cls):
+        code = InvalidLinkBear.get_status_code_or_error("http://www.google.com")
+        return ("You are not connected to the internet."
+                if code is None else True)
+
+    @staticmethod
+    def get_status_code_or_error(url):
+        try:
+            code = requests.head(url, allow_redirects=False).status_code
+            return code
+        except requests.exceptions.RequestException:
+            pass
+
+    @staticmethod
+    def find_links_in_file(file):
+        regex = re.compile(
+            r'((ftp|http)s?:\/\/\S+\.(?:[^\s\(\)\'\>]+|'
+            r'\([^\s\(\)]*\))*)(?<!\.)(?<!\,)')
+        for line_number, line in enumerate(file):
+            match = regex.search(line)
+            if match:
+                link = match.group()
+                code = InvalidLinkBear.get_status_code_or_error(link)
+                yield line_number + 1, link, code
+
+    def run(self, filename, file):
+        '''
+        Yields results for all invalid links in a file.
+        '''
+        for line_number, link, code in InvalidLinkBear.find_links_in_file(file):
+            if code is None:
+                yield Result.from_values(
+                    origin=self,
+                    message='Broken link - unable to connect to this url.',
+                    file=filename,
+                    line=line_number,
+                    severity=RESULT_SEVERITY.MAJOR)
+            elif not 200 <= code < 300:
+                if 400 <= code < 600:  # HTTP status 40x or 50x
+                    yield Result.from_values(
+                        origin=self,
+                        message='Broken link - unable to connect to this url.' +
+                                ' (HTTP Error: {code})'.format(code=code),
+                        file=filename,
+                        line=line_number,
+                        severity=RESULT_SEVERITY.NORMAL)
+                if 300 <= code < 400:  # HTTP status 30x
+                    redirect_url = requests.head(link, allow_redirects=True).url
+                    diff = Diff(file)
+                    current_line = file[line_number - 1]
+                    start = current_line.find(link)
+                    end = start + len(link)
+                    replacement = current_line[:start] + \
+                        redirect_url + current_line[end:]
+                    diff.change_line(line_number, current_line, replacement)
+
+                    yield Result.from_values(
+                        self,
+                        'This link redirects to ' + redirect_url,
+                        diffs={filename: diff},
+                        file=filename,
+                        line=line_number,
+                        severity=RESULT_SEVERITY.NORMAL)

--- a/bears/tests/general/InvalidLinkBearTest.py
+++ b/bears/tests/general/InvalidLinkBearTest.py
@@ -1,0 +1,40 @@
+from bears.general.InvalidLinkBear import InvalidLinkBear
+from bears.tests.LocalBearTestHelper import verify_local_bear
+
+LinkRedirect = verify_local_bear(InvalidLinkBear,
+                                 valid_files=(
+                                    ["http://httpbin.org/status/200"]),
+                                 invalid_files=(
+                                    ["http://httpbin.org/status/301"],
+                                    ["http://coala.rtfd.org"]),)
+
+InvalidLinkNotFound = verify_local_bear(InvalidLinkBear,
+                                        valid_files=(
+                                            ["http://httpbin.org/status/202"]),
+                                        invalid_files=(
+                                            ["http://httpbin.org/status/404"],
+                                            ["http://httpbin.org/status/401"]),)
+
+InvalidLinkServerError = verify_local_bear(InvalidLinkBear,
+                                           valid_files=(
+                                            ["http://httpbin.org/status/202"]),
+                                           invalid_files=(
+                                            ["http://httpbin.org/status/500"],
+                                            ["http://httpbin.org/status/503"],))
+
+LinkDoesNotExist = verify_local_bear(InvalidLinkBear,
+                                     valid_files=(
+                                        ["http://coala-analyzer.org/"],
+                                        ["http://not a link dot com"],
+                                        ["<http://lwn.net/>"],
+                                        ["'https://www.gnome.org/'"],
+                                        ["http://coala-analyzer.org/..."]),
+                                     invalid_files=(
+                                        ["http://coalaisthebest.com"],))
+
+MarkdownLinks = verify_local_bear(InvalidLinkBear,
+                                  valid_files=(
+                                        ["[coala](http://coala-analyzer.org/)"],
+                                        ["https://en.wikipedia.org/wiki/"
+                                         "Hello_(Adele_song)"]),
+                                  invalid_files=())

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ html-linter>=0.3.0
 libclang-py3==0.2
 guess-language-spirit>=0.5.2
 radon>=1.2.2
+requests>=2.9.1


### PR DESCRIPTION
Check for broken links

Search for every link in a file, and send a GET
request to each of them to check if they are valid.

If any of them do not send a HTTP status 200 back, then:

- if the status code is 30x:
    the redirect url is fetched and a diff is shown to update the
    url.
- if the status code is 50x or 40x:
    The message "Broken link - unable to connect to this url."
    along with the status code is displayed.
- if the GET request fails:
    The message "Broken link - unable to connect to this url."
    is displayed.

InvalidLinkBear also checks for internet connection, as a
prerequisite.

Fixes https://github.com/coala-analyzer/coala-bears/issues/29