### PR TITLE
InvalidLinkBear: Do not include trailing |

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -26,7 +26,7 @@ class InvalidLinkBear(LocalBear):
     @staticmethod
     def find_links_in_file(file):
         regex = re.compile(
-            r'((ftp|http)s?:\/\/\S+\.(?:[^\s\(\)\'\>]+|'
+            r'((ftp|http)s?:\/\/\S+\.(?:[^\s\(\)\'\>\|]+|'
             r'\([^\s\(\)]*\))*)(?<!\.)(?<!\,)')
         for line_number, line in enumerate(file):
             match = regex.search(line)

--- a/bears/tests/general/InvalidLinkBearTest.py
+++ b/bears/tests/general/InvalidLinkBearTest.py
@@ -38,3 +38,9 @@ MarkdownLinks = verify_local_bear(InvalidLinkBear,
                                         ["https://en.wikipedia.org/wiki/"
                                          "Hello_(Adele_song)"]),
                                   invalid_files=())
+
+SphinxLinks = verify_local_bear(InvalidLinkBear,
+                                valid_files=(
+                                    ["|https://github.com/coala-analyzer/"
+                                     "coala-bears|"]),
+                                invalid_files=())


### PR DESCRIPTION
|<link>| These are links in Sphinx, this commit parses the link
correctly, without including the trailing |

Fixes coala-analyzer/coala-bears#58