### PR TITLE
setup.cfg: Ignore file test-requirements.txt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,10 @@ cover_pylib = False
 source =
     .
 omit = 
-	tests/*
-	.ci/*
-	setup.py
+    tests/*
+    .ci/*
+    setup.py
+    test-requirements.txt
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
I have omitted the unwanted file (test-requirements.txt) in setup.cfg as it gets picked up when running py.test because of the test- prefix.

Fixes https://github.com/coala-analyzer/coala-bears/issues/71