### PR TITLE
InvalidLinkBear: Set timeout for requests

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -18,7 +18,8 @@ class InvalidLinkBear(LocalBear):
     @staticmethod
     def get_status_code_or_error(url):
         try:
-            code = requests.head(url, allow_redirects=False).status_code
+            code = requests.head(url, allow_redirects=False,
+                                 timeout=1).status_code
             return code
         except requests.exceptions.RequestException:
             pass


### PR DESCRIPTION
A timeout of 1s is added so that the tests do not get timed out.

Fixes https://github.com/coala-analyzer/coala-bears/issues/111