### PR TITLE
bears/__init__.py: import constants

### DIFF
--- a/bears/__init__.py
+++ b/bears/__init__.py
@@ -1,4 +1,7 @@
 import sys
+from bears import Constants
+
+__version__ = Constants.VERSION
 
 
 def assert_supported_version():  # pragma: no cover


### PR DESCRIPTION
Add the version constants from Constants.py. Add variable "__version__".

Fixes https://github.com/coala-analyzer/coala-bears/issues/84