### PR TITLE
bears: Add PyDocStyleBear

### DIFF
--- a/bears/python/PyDocStyleBear.py
+++ b/bears/python/PyDocStyleBear.py
@@ -1,0 +1,15 @@
+from coalib.bearlib.abstractions.Lint import Lint
+from coalib.bears.LocalBear import LocalBear
+
+
+class PyDocStyleBear(LocalBear, Lint):
+    executable = 'pydocstyle'
+    arguments = '{filename}'
+    output_regex = r'(.*\.py):(?P<line>\d+) (.+):\n\s+(?P<message>.*)'
+    use_stderr = True
+
+    def run(self, filename, file):
+        '''
+        Checks python docstrings.
+        '''
+        return self.lint(filename, file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ radon>=1.2.2
 requests>=2.9.1
 yamllint>=1.0.1
 cppclean>=0.9
+pydocstyle>=1.0.0

--- a/tests/python/PyDocStyleBearTest.py
+++ b/tests/python/PyDocStyleBearTest.py
@@ -1,0 +1,29 @@
+from bears.python.PyDocStyleBear import PyDocStyleBear
+from tests.LocalBearTestHelper import verify_local_bear
+
+
+good_file = '''
+"""example module level docstring."""
+
+
+def hello():
+    """Print hello world."""
+    print("hello world")
+
+'''.splitlines(keepends=True)
+
+
+bad_file = '''
+"""
+example module level docstring
+"""
+
+def hello():
+    print("hello world")
+
+'''.splitlines(keepends=True)
+
+PyDocStyleBearTest = verify_local_bear(PyDocStyleBear,
+                                       valid_files=(good_file,),
+                                       invalid_files=(bad_file,),
+                                       tempfile_kwargs={"suffix": ".py"})


### PR DESCRIPTION
Uses pydocstyle(https://github.com/PyCQA/pydocstyle) to check for
docstring style.

Fixes https://github.com/coala-analyzer/coala-bears/issues/130