### PR TITLE
setup.cfg: Ignore file test-requirements.txt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ python_files = *Test.py
 python_classes = *Test
 python_functions = *_test
 timeout = 35
-addopts = --color=yes
+addopts = --color=yes --ignore=test-requirements.txt
 env =
     PYTHONHASHSEED=0
 # PYTHONHASHSEED=0 is required to use same hashes in pytests-xdist's workers


### PR DESCRIPTION
`test-requirements.txt` has been added to addopts --ignore flag which ensures
it doesn't get picked up when using `py.test`

Fixes https://github.com/coala-analyzer/coala-bears/issues/71

Sorry for opening a new PR, the old one had a dirty commit history and I no longer had that copy of the repo. Closing the previous one.