### PR TITLE
requirements: Update coala version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coala>=0.4.2.dev20160225113449
+coala>=0.4.2.dev20160304094246
 setuptools>=19.2
 munkres3>=1.0.5.5
 pylint>=1.5.2


### PR DESCRIPTION
Previous coala versions didn't have coalang files
packaged into them, and also had some problems with the keys
version 0.4.2.dev20160304094246 has all that fixed and that is also
required by the upcoming IndentationBear