### PR TITLE
deps.sh: Don't download dart-sdk if it exists

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -55,8 +55,10 @@ done
 python setup.py --help
 
 # Dart Lint commands
-wget -nc -O ~/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/1.14.2/sdk/dartsdk-linux-x64-release.zip
-unzip -n ~/dart-sdk.zip -d ~/
+if ! dartanalyzer -v &> /dev/null ; then
+  wget -nc -O ~/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/1.14.2/sdk/dartsdk-linux-x64-release.zip
+  unzip -n ~/dart-sdk.zip -d ~/
+fi
 
 # Julia commands
 julia -e "Pkg.add(\"Lint\")"


### PR DESCRIPTION
Downloads and installs dart-sdk only if it doesn't exist already.

Fixes https://github.com/coala-analyzer/coala-bears/issues/157