### PR TITLE
requirements.txt: Fix radon version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ html-linter>=0.3.0
 # Do *not* use 0.3 which is not backwards compatible to common clang versions
 libclang-py3==0.2
 guess-language-spirit>=0.5.2
-radon>=1.2.2
+radon==1.2.2
 requests>=2.9.1
 yamllint>=1.0.1
 cppclean>=0.9


### PR DESCRIPTION
radon introduces version conflicts with 1.2.3. Limitting version until
we find a solution to that.