### PR TITLE
ESLintBearTest.py: Remove the extra comma

### DIFF
--- a/tests/js/ESLintBearTest.py
+++ b/tests/js/ESLintBearTest.py
@@ -37,4 +37,4 @@ ESLintBearTestWithConfig = verify_local_bear(ESLintBear,
 
 ESLintBearWithoutConfig = verify_local_bear(ESLintBear,
                                             valid_files=(test_good, test_bad),
-                                            invalid_files=(),)
+                                            invalid_files=())


### PR DESCRIPTION
Remove the extra comma after invalid_files=()

Fixes https://github.com/coala-analyzer/coala-bears/issues/188