### PR TITLE
Move requests_mock to test-requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,3 @@ yamllint>=1.0.1
 cppclean>=0.9
 pydocstyle>=1.0.0
 cmakelint>=1.3.4
-requests_mock>=0.7.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ pytest-cov>=2.2.1
 pytest-env>=0.6.0
 pytest-timeout>=1.0.0
 pytest-xdist>=1.14
+requests_mock>=0.7.0


### PR DESCRIPTION
Moved the requirement: 

> `requests_mock>=0.7.0`

 from "_requirements.txt_" to "_test-requirements.txt_"

Fixes https://github.com/coala-analyzer/coala-bears/issues/180