### PR TITLE
bears/ruby: Add RuboCopBear

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
 ruby '2.1.5'
 
+gem "rubocop"
 gem "sqlint"
 gem 'scss_lint', require: false# require flag is necessary https://github.com/brigade/scss-lint#installation

--- a/bears/ruby/RuboCopBear.py
+++ b/bears/ruby/RuboCopBear.py
@@ -1,0 +1,47 @@
+import json
+
+from coalib.bearlib.abstractions.Lint import Lint
+from coalib.bears.LocalBear import LocalBear
+from coalib.results.Diff import Diff
+from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
+from coalib.results.Result import Result
+
+
+class RuboCopBear(LocalBear, Lint):
+    executable = 'rubocop'
+    # Need both stdin and filename. Explained in the comment:
+    # https://github.com/bbatsov/rubocop/pull/2146#issuecomment-131403694
+    arguments = '{filename} --stdin --format=json'
+    severity_map = {
+        "error": RESULT_SEVERITY.MAJOR,
+        "warning": RESULT_SEVERITY.NORMAL,
+        "convention": RESULT_SEVERITY.INFO
+    }
+    use_stdin = True
+
+    def run(self, filename, file):
+        '''
+        Checks the code with ``rubocop``. This will run ``rubocop``
+        over each of the files separately.
+        '''
+        return self.lint(filename, file)
+
+    def _process_issues(self, output, filename):
+        output = json.loads("".join(output))
+        assert len(output['files']) == 1
+        for result in output['files'][0]['offenses']:
+            # TODO: Add condition for auto-correct, when rubocop is updated.
+            # Relevant Issue: https://github.com/bbatsov/rubocop/issues/2932
+            yield Result.from_values(
+                origin="{class_name} ({rule})".format(
+                    class_name=self.__class__.__name__,
+                    rule=result['cop_name']),
+                message=result['message'],
+                file=filename,
+                diffs=None,
+                severity=self.severity_map[result['severity']],
+                line=result['location']['line'],
+                column=result['location']['column'],
+                # Tested with linebreaks, it's secure.
+                end_column=result['location']['column'] +
+                result['location']['length'])

--- a/tests/ruby/RuboCopBearTest.py
+++ b/tests/ruby/RuboCopBearTest.py
@@ -1,0 +1,19 @@
+from bears.ruby.RuboCopBear import RuboCopBear
+from tests.LocalBearTestHelper import verify_local_bear
+
+good_file = """def bad_name
+  test if something
+end
+""".splitlines(keepends=True)
+
+bad_file = """def badName
+  if something
+    test
+    end
+end
+""".splitlines(keepends=True)
+
+
+RuboCopBearTest = verify_local_bear(RuboCopBear,
+                                    invalid_files=(bad_file,),
+                                    valid_files=(good_file,))


### PR DESCRIPTION
Add `rubocop` support for Ruby static code analyzer.

Fixes: https://github.com/coala-analyzer/coala-bears/issues/189