### PR TITLE
Ruby syntax bear

### DIFF
--- a/bears/ruby/RubySyntaxBear.py
+++ b/bears/ruby/RubySyntaxBear.py
@@ -5,7 +5,7 @@ from coalib.bears.LocalBear import LocalBear
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
-class RubyLintBear(LocalBear, Lint):
+class RubySyntaxBear(LocalBear, Lint):
     executable = 'ruby'
     arguments = '-wc {filename}'
     output_regex = re.compile(

--- a/tests/ruby/RubySyntaxBearTest.py
+++ b/tests/ruby/RubySyntaxBearTest.py
@@ -1,4 +1,4 @@
-from bears.ruby.RubyLintBear import RubyLintBear
+from bears.ruby.RubySyntaxBear import RubySyntaxBear
 from tests.LocalBearTestHelper import verify_local_bear
 
 good_file = """
@@ -25,6 +25,6 @@ class HelloWorld
 """.splitlines(keepends=True)
 
 
-RubyLintBearTest = verify_local_bear(RubyLintBear,
-                                     valid_files=(good_file,),
-                                     invalid_files=(bad_file,))
+RubySyntaxBearTest = verify_local_bear(RubySyntaxBear,
+                                       valid_files=(good_file,),
+                                       invalid_files=(bad_file,))


### PR DESCRIPTION
RubyLintBear is now RubySyntaxBear because of
a new `ruby-lint` bear to be added and this name
makes more sense.

Fixes: coala-analyzer#190