### PR TITLE
Clone Detection: Made variable type a property

### DIFF
--- a/bears/c_languages/codeclone_detection/ClangCountVectorCreator.py
+++ b/bears/c_languages/codeclone_detection/ClangCountVectorCreator.py
@@ -39,10 +39,10 @@ class ClangCountVectorCreator:
         self.count_vectors = {}
         self.stack = []
 
-    def count_identifier(self, identifier):
+    def count_identifier(self, identifier, category):
         if identifier not in self.count_vectors:
-            self.count_vectors[identifier] = (
-                CountVector(identifier, self.conditions, self.weightings))
+            self.count_vectors[identifier] = CountVector(
+                identifier, category, self.conditions, self.weightings)
 
         self.count_vectors[identifier].count_reference(self.stack)
 
@@ -64,14 +64,13 @@ class ClangCountVectorCreator:
         self.stack.append((cursor, child_num))
 
         if is_reference(cursor):
-            self.count_identifier(get_identifier_name(cursor))
+            self.count_identifier(get_identifier_name(cursor),
+                                  CountVector.Category.reference)
         if is_literal(cursor):
             tokens = list(cursor.get_tokens())
             if tokens:
-                # Mangle constants with $ (-> no valid C identifier), first
-                # token is the constant, semicolon and similar things may
-                # follow, don't want them
-                self.count_identifier("#" + tokens[0].spelling)
+                self.count_identifier(tokens[0].spelling,
+                                      CountVector.Category.literal)
 
         for i, child in enumerate(cursor.get_children()):
             self._get_vector_for_function(child, i)

--- a/bears/c_languages/codeclone_detection/CloneDetectionRoutines.py
+++ b/bears/c_languages/codeclone_detection/CloneDetectionRoutines.py
@@ -5,6 +5,7 @@ import os
 from munkres import Munkres
 
 from coalib.collecting.Collectors import collect_dirs
+from bears.c_languages.codeclone_detection.CountVector import CountVector
 
 # Instantiate globally since this class is holding stateless public methods.
 munkres = Munkres()
@@ -24,11 +25,12 @@ def exclude_function(count_matrix):
                          variables for a function.
     :return:             True if the function is useless for evaluation.
     """
-    var_count = [cv.name.startswith("#")
-                 for cv in count_matrix.values()].count(False)
-    variable_sum = sum(0 if cv.name.startswith("#") else sum(cv.unweighted)
-                       for cv in count_matrix.values())
-    return (all((cv.name.startswith("#") or sum(cv.unweighted) < 10)
+    var_list = [cv for cv in count_matrix.values()
+                if cv.category is CountVector.Category.reference]
+    var_count = len(var_list)
+    variable_sum = sum(sum(cv.unweighted) for cv in var_list)
+    return (all((cv.category is CountVector.Category.literal or
+                 sum(cv.unweighted) < 10)
                 for cv in count_matrix.values()) or
             variable_sum < 11 or
             var_count < 2)

--- a/bears/c_languages/codeclone_detection/CountVector.py
+++ b/bears/c_languages/codeclone_detection/CountVector.py
@@ -6,11 +6,19 @@ from coalib.misc.Decorators import generate_repr
 @generate_repr()
 class CountVector:
 
-    def __init__(self, name, conditions=None, weightings=None):
+    class Category:
+        """
+        Iternal class to specify the type of the variable in the original code
+        """
+        reference = 0
+        literal = 1
+
+    def __init__(self, name, category=None, conditions=None, weightings=None):
         """
         Creates a new count vector.
 
         :param name:       The name of the variable in the original code.
+        :param category:   The category of the variable.
         :param conditions: The counting conditions as list of function objects,
                            each shall return true when getting data indicating
                            that this occurrence should be counted.
@@ -18,6 +26,7 @@ class CountVector:
                            Defaults to 1 for all conditions.
         """
         self.name = name
+        self.category = category
         self.conditions = conditions if conditions is not None else []
         self.count_vector = [0 for elem in self.conditions]
         self.unweighted = [0 for elem in self.conditions]
@@ -34,7 +43,10 @@ class CountVector:
 
         :return: A CountVector object.
         """
-        return CountVector(name, self.conditions, self.weightings)
+        return CountVector(name,
+                           category=self.category,
+                           conditions=self.conditions,
+                           weightings=self.weightings)
 
     def count_reference(self, *args, **kwargs):
         """

--- a/tests/c_languages/codeclone_detection/ClangCountVectorCreatorTest.py
+++ b/tests/c_languages/codeclone_detection/ClangCountVectorCreatorTest.py
@@ -44,8 +44,8 @@ class ClangCountVectorCreatorTest(unittest.TestCase):
                 "smile": [],
                 "printf": [],
                 # Constants
-                "#5": [],
-                '#"i is %d"': []}}
+                "5": [],
+                '"i is %d"': []}}
 
         self.uut = ClangCountVectorCreator()
         cv_dict = self.uut.get_vectors_for_file(self.testfile)
@@ -79,8 +79,8 @@ class ClangCountVectorCreatorTest(unittest.TestCase):
                 "smile": [1, 1],
                 "printf": [1, 1],
                 # Constants
-                "#5": [1, 0],
-                '#"i is %d"': [1, 1]}}
+                "5": [1, 0],
+                '"i is %d"': [1, 1]}}
 
         self.uut = ClangCountVectorCreator([no_condition, is_call_argument])
         cv_dict = self.uut.get_vectors_for_file(self.testfile)

--- a/tests/c_languages/codeclone_detection/ClangCountingConditionsTest.py
+++ b/tests/c_languages/codeclone_detection/ClangCountingConditionsTest.py
@@ -60,7 +60,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"a": [5],
              "b": [6],
              "foo": [1],
-             "#0": [1]})
+             "0": [1]})
 
     def test_is_called(self):
         self.check_counting_condition(
@@ -69,7 +69,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"a": [0],
              "b": [0],
              "foo": [1],
-             "#0": [0]})
+             "0": [0]})
 
     def test_is_call_param(self):
         self.check_counting_condition(
@@ -78,7 +78,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"a": [0],
              "b": [1],
              "foo": [0],
-             "#0": [0]})
+             "0": [0]})
 
     def test_returned(self):
         self.check_counting_condition(
@@ -93,7 +93,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             (22, "loopy(int, int)"),
             {"a": [2],
              "b": [1],
-             "#0": [0]})
+             "0": [0]})
 
     def test_in_condition(self):
         self.check_counting_condition(
@@ -110,11 +110,11 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"first": [3],
              "second": [0],
              "third": [0],
-             "#0": [0],
-             "#1": [2],
-             "#2": [2],
-             "#3": [0],
-             "#5": [0]})
+             "0": [0],
+             "1": [2],
+             "2": [2],
+             "3": [0],
+             "5": [0]})
 
         self.check_counting_condition(
             "in_second_level_condition",
@@ -122,11 +122,11 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"first": [0],
              "second": [1],
              "third": [0],
-             "#0": [0],
-             "#1": [1],
-             "#2": [0],
-             "#3": [1],
-             "#5": [0]})
+             "0": [0],
+             "1": [1],
+             "2": [0],
+             "3": [1],
+             "5": [0]})
 
         self.check_counting_condition(
             "in_third_level_condition",
@@ -134,11 +134,11 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"first": [0],
              "second": [0],
              "third": [2],
-             "#0": [0],
-             "#1": [0],
-             "#2": [1],
-             "#3": [1],
-             "#5": [0]})
+             "0": [0],
+             "1": [0],
+             "2": [1],
+             "3": [1],
+             "5": [0]})
 
     def test_is_assignee(self):
         self.check_counting_condition(
@@ -146,7 +146,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             (62, "assignation(int, int)"),
             {"a": [3],
              "b": [9],
-             "#1": [0]})
+             "1": [0]})
 
     def test_is_assigner(self):
         self.check_counting_condition(
@@ -154,7 +154,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             (62, "assignation(int, int)"),
             {"a": [6],
              "b": [9],
-             "#1": [4]})
+             "1": [4]})
 
     def test_loop_content(self):
         self.check_counting_condition(
@@ -162,7 +162,7 @@ class ClangCountingConditionsTest(unittest.TestCase):
             (22, "loopy(int, int)"),
             {"a": [0],
              "b": [6],
-             "#0": [0]})
+             "0": [0]})
 
         self.check_counting_condition(
             "loop_content",
@@ -170,11 +170,11 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"first": [1],
              "second": [0],
              "third": [0],
-             "#0": [0],
-             "#1": [2],
-             "#2": [0],
-             "#3": [0],
-             "#5": [0]})
+             "0": [0],
+             "1": [2],
+             "2": [0],
+             "3": [0],
+             "5": [0]})
 
         self.check_counting_condition(
             "second_level_loop_content",
@@ -182,11 +182,11 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"first": [0],
              "second": [1],
              "third": [0],
-             "#0": [0],
-             "#1": [0],
-             "#2": [2],
-             "#3": [0],
-             "#5": [0]})
+             "0": [0],
+             "1": [0],
+             "2": [2],
+             "3": [0],
+             "5": [0]})
 
         self.check_counting_condition(
             "third_level_loop_content",
@@ -194,11 +194,11 @@ class ClangCountingConditionsTest(unittest.TestCase):
             {"first": [0],
              "second": [0],
              "third": [2],
-             "#0": [0],
-             "#1": [0],
-             "#2": [0],
-             "#3": [1],
-             "#5": [1]})
+             "0": [0],
+             "1": [0],
+             "2": [0],
+             "3": [1],
+             "5": [1]})
 
     def test_is_param(self):
         self.check_counting_condition(
@@ -215,21 +215,21 @@ class ClangCountingConditionsTest(unittest.TestCase):
             (89, "arithmetics(int, int)"),
             {"a": [4],
              "b": [3],
-             "#4": [1]})
+             "4": [1]})
 
         self.check_counting_condition(
             "in_product",
             (89, "arithmetics(int, int)"),
             {"a": [6],
              "b": [6],
-             "#4": [0]})
+             "4": [0]})
 
         self.check_counting_condition(
             "in_binary_operation",
             (89, "arithmetics(int, int)"),
             {"a": [6],
              "b": [2],
-             "#4": [0]})
+             "4": [0]})
 
     def test_member_accessed(self):
         self.check_counting_condition(
@@ -237,5 +237,5 @@ class ClangCountingConditionsTest(unittest.TestCase):
             (149, "structing(struct test_struct, struct test_struct *)"),
             {"a": [1],
              "b": [1],
-             "#1": [0],
-             "#2": [1]})
+             "1": [0],
+             "2": [1]})

--- a/tests/c_languages/codeclone_detection/CountVectorTest.py
+++ b/tests/c_languages/codeclone_detection/CountVectorTest.py
@@ -14,18 +14,19 @@ class CountVectorTest(unittest.TestCase):
         self.assertRaises(AssertionError,
                           CountVector,
                           "varname",
-                          [],
-                          [2])
+                          conditions=[],
+                          weightings=[2])
 
     def test_len(self):
         uut = CountVector("varname")
         self.assertEqual(len(uut), 0)
 
-        uut = CountVector("varname", [lambda x: x])
+        uut = CountVector("varname", conditions=[lambda x: x])
         self.assertEqual(len(uut), 1)
 
     def test_counting(self):
-        uut = CountVector("varname", [lambda cursor, stack: cursor and stack])
+        uut = CountVector("varname",
+                          conditions=[lambda cursor, stack: cursor and stack])
         self.assertEqual(uut.count_vector, [0])
         uut.count_reference(True, True)
         self.assertEqual(uut.count_vector, [1])
@@ -35,9 +36,9 @@ class CountVectorTest(unittest.TestCase):
 
     def test_weighting(self):
         uut = CountVector("varname",
-                          [lambda cursor, stack: cursor and stack,
-                           lambda cursor, stack: cursor],
-                          [2, 1])
+                          conditions=[lambda cursor, stack: cursor and stack,
+                                      lambda cursor, stack: cursor],
+                          weightings=[2, 1])
         uut.count_reference(True, True)
         self.assertEqual(uut.count_vector, [2, 1])
         self.assertEqual(uut.unweighted, [1, 1])
@@ -47,16 +48,16 @@ class CountVectorTest(unittest.TestCase):
 
     def test_conversions(self):
         uut = CountVector("varname",
-                          [lambda cursor, stack: cursor and stack],
-                          [2])
+                          conditions=[lambda cursor, stack: cursor and stack],
+                          weightings=[2])
         uut.count_reference(True, True)
         self.assertEqual(str(uut), "[2]")
         self.assertEqual(list(uut), [2])
 
     def test_cloning(self):
         uut = CountVector("varname",
-                          [lambda cursor, stack: cursor and stack],
-                          [2])
+                          conditions=[lambda cursor, stack: cursor and stack],
+                          weightings=[2])
         uut.count_reference(True, True)
         clone = uut.create_null_vector("test")
         self.assertEqual(clone.name, "test")
@@ -66,7 +67,7 @@ class CountVectorTest(unittest.TestCase):
 
     def test_abs(self):
         uut = CountVector("varname",
-                          [lambda x: True, lambda x: x])
+                          conditions=[lambda x: True, lambda x: x])
         self.assertEqual(abs(uut), 0)
         uut.count_reference(True)
         self.assertEqual(abs(uut), sqrt(2))
@@ -89,8 +90,10 @@ class CountVectorTest(unittest.TestCase):
                                     (string).
         """
         # Create empty CountVector objects
-        count_vector1 = CountVector("", [lambda: False for i in cv1])
-        count_vector2 = CountVector("", [lambda: False for i in cv2])
+        count_vector1 = CountVector("",
+                                    conditions=[lambda: False for i in cv1])
+        count_vector2 = CountVector("",
+                                    conditions=[lambda: False for i in cv2])
         # Manually hack in the test values
         count_vector1.count_vector = cv1
         count_vector2.count_vector = cv2


### PR DESCRIPTION
Instead of name mangling added one more property to the CountVector
class to save the type of variable in the original code.
Fixes https://github.com/coala-analyzer/coala-bears/issues/38