### PR TITLE
deps: Auto reply yes for prompts in apt-get

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -13,12 +13,12 @@ esac
 sudo add-apt-repository -y ppa:marutter/rdev
 sudo add-apt-repository -y ppa:staticfloat/juliareleases
 sudo add-apt-repository -y ppa:staticfloat/julia-deps
-sudo apt-get update
+sudo apt-get -y update
 deps="espeak libclang1-3.4 indent mono-mcs chktex hlint r-base julia luarocks"
 deps_python_dbus="libdbus-glib-1-dev libdbus-1-dev"
 deps_python_gi="glib2.0-dev gobject-introspection libgirepository1.0-dev python3-cairo-dev"
 deps_perl="perl libperl-critic-perl"
-sudo apt-get install $deps $deps_python_gi $deps_python_dbus $deps_perl > /dev/null
+sudo apt-get -y install $deps $deps_python_gi $deps_python_dbus $deps_perl
 
 # Update hlint to latest version (not available in apt)
 wget https://launchpad.net/ubuntu/+source/hlint/1.9.26-1/+build/8831318/+files/hlint_1.9.26-1_amd64.deb


### PR DESCRIPTION
Earlier we had removed the `-qq` flag in apt-get and
not added the -y. -qq automatically added the -y and so
If a rebuild without cache is done, this will hang.