### PR TITLE
setup: Change position of urllib import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import sys
 from os.path import exists
 from shutil import copyfileobj
 from subprocess import call
-from urllib.request import urlopen
 
 # Start ignoring PyImportSortBear as imports below may yield syntax errors
 from bears import assert_supported_version
@@ -13,6 +12,7 @@ from bears import assert_supported_version
 assert_supported_version()
 # Stop ignoring
 
+from urllib.request import urlopen
 import setuptools.command.build_py
 from bears import Constants
 from setuptools import find_packages, setup

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+
+# Start ignoring PyImportSortBear as imports below may yield syntax errors
+from bears import assert_supported_version
 assert_supported_version()
 # Stop ignoring
 
@@ -9,10 +12,6 @@ from os.path import exists
 from shutil import copyfileobj
 from subprocess import call
 from urllib.request import urlopen
-
-# Start ignoring PyImportSortBear as imports below may yield syntax errors
-from bears import assert_supported_version
-
 
 import setuptools.command.build_py
 from bears import Constants

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
+assert_supported_version()
+# Stop ignoring
+
 import locale
 import sys
 from os.path import exists
 from shutil import copyfileobj
 from subprocess import call
+from urllib.request import urlopen
 
 # Start ignoring PyImportSortBear as imports below may yield syntax errors
 from bears import assert_supported_version
 
-assert_supported_version()
-# Stop ignoring
 
-from urllib.request import urlopen
 import setuptools.command.build_py
 from bears import Constants
 from setuptools import find_packages, setup


### PR DESCRIPTION
When installing via setup.py (using python2), the setup doesn't assert
the requirement of python3. Instead, it throws an error. This is fixed
by shifting one the 'from urllib.request import urlopen' import
statement, as it requires python3.

Fixes https://github.com/coala-analyzer/coala-bears/issues/223