### PR TITLE
setup: Change position of all imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 
+# Start ignoring PyImportSortBear as imports below may yield syntax errors
+from bears import assert_supported_version
+assert_supported_version()
+# Stop ignoring
+
 import locale
 import sys
 from os.path import exists
 from shutil import copyfileobj
 from subprocess import call
 from urllib.request import urlopen
-
-# Start ignoring PyImportSortBear as imports below may yield syntax errors
-from bears import assert_supported_version
-
-assert_supported_version()
-# Stop ignoring
 
 import setuptools.command.build_py
 from bears import Constants


### PR DESCRIPTION
Shifted assertion for python3 above all imports, as some of
the imports might not work with python2.

Fixes https://github.com/coala-analyzer/coala-bears/issues/223