### PR TITLE
bears/r: Add Skip condition for FormatRBear

### DIFF
--- a/bears/r/FormatRBear.py
+++ b/bears/r/FormatRBear.py
@@ -5,6 +5,8 @@ from coalib.bears.LocalBear import LocalBear
 class FormatRBear(Lint, LocalBear):
     executable = "Rscript"
     arguments = "-e 'library(formatR)' -e 'formatR::tidy_source({filename})'"
+    prerequisite_command = ['Rscript', '-e', "'library(formatR)'"]
+    prerequisite_fail_msg = "Please install formatR for this bear to work."
     diff_message = "Formatting can be improved."
     gives_corrected = True
 


### PR DESCRIPTION
`prerequisite_command` and `prerequisite_message` added
to FormatRBear to check prerequisite.

Fixes https://github.com/coala-analyzer/coala-bears/issues/221