### PR TITLE
PerlCriticBear: Replace inline config with file

### DIFF
--- a/bears/perl/PerlCriticBear.py
+++ b/bears/perl/PerlCriticBear.py
@@ -21,16 +21,16 @@ class PerlCriticBear(LocalBear, Lint):
     def run(self,
             filename,
             file,
-            perlcritic_config: str=""):
+            perlcritic_profile: str=""):
         '''
         Checks the code with perlcritic. This will run perlcritic over
         each of the files seperately
 
-        :param perlcritic_config: Location of the perlcriticrc config file.
+        :param perlcritic_profile: Location of the perlcriticrc config file.
         '''
         self.arguments = '--no-color --verbose "%l|%c|%s|%p|%m (%e)"'
-        if perlcritic_config:
-            self.arguments += (" --config "
-                               + escape_path_argument(perlcritic_config))
+        if perlcritic_profile:
+            self.arguments += (" --profile "
+                               + escape_path_argument(perlcritic_profile))
         self.arguments += " {filename}"
         return self.lint(filename)

--- a/tests/perl/PerlCriticBearTest.py
+++ b/tests/perl/PerlCriticBearTest.py
@@ -1,3 +1,5 @@
+import os
+
 from bears.perl.PerlCriticBear import PerlCriticBear
 from tests.LocalBearTestHelper import verify_local_bear
 from coalib.misc.ContextManagers import prepare_file
@@ -26,28 +28,16 @@ print "Hello World\n";
 """.splitlines(keepends=True)
 
 
-config_file = """
-severity  = 5
-# for signatures
-[-Subroutines::ProhibitSubroutinePrototypes]
-
-[TestingAndDebugging::RequireUseStrict]
-
-[TestingAndDebugging::RequireUseWarnings]
-""".splitlines(keepends=True)
-
+conf_file = os.path.abspath(os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "testfiles", ".perlcriticrc"))
 
 PerlCriticBearTest = verify_local_bear(PerlCriticBear,
                                        valid_files=(good_file,),
                                        invalid_files=(bad_file,))
 
-
-with prepare_file(config_file,
-                  filename=None,
-                  force_linebreaks=True,
-                  create_tempfile=True) as (conf_lines, conf_file):
-    PerlCriticBearConfigTest = verify_local_bear(
-        PerlCriticBear,
-        valid_files=(bad_file, good_file),
-        invalid_files=(),
-        settings={"perlcritic_config": conf_file})
+PerlCriticBearConfigTest = verify_local_bear(
+    PerlCriticBear,
+    valid_files=(good_file, bad_file),
+    invalid_files=(),
+    settings={"perlcritic_profile": conf_file})

--- a/tests/perl/testfiles/.perlcriticrc
+++ b/tests/perl/testfiles/.perlcriticrc
@@ -1,0 +1,8 @@
+severity  = 5
+# for signatures
+[-Subroutines::ProhibitSubroutinePrototypes]
+
+[-TestingAndDebugging::RequireUseStrict]
+
+[TestingAndDebugging::RequireUseWarnings]
+


### PR DESCRIPTION
PerlCriticBear currently gives an exception when ran because the
`--config` argument does not exist. This should be `--profile`
instead.

Also, due to a known bug in temporary file creation, the inline
configuration file in PerCriticBearTest is moved to a directory
testfiles/ and the configuration file is placed there.

Fixes https://github.com/coala-analyzer/coala-bears/issues/109