### PR TITLE
ClangCodeCloneDetectionBear: Add switch support

### DIFF
--- a/bears/c_languages/codeclone_detection/ClangCountingConditions.py
+++ b/bears/c_languages/codeclone_detection/ClangCountingConditions.py
@@ -302,6 +302,8 @@ def is_condition(stack):
     """
     return (_is_nth_child_of_kind(stack, [0], CursorKind.WHILE_STMT) != 0 or
             _is_nth_child_of_kind(stack, [0], CursorKind.IF_STMT) != 0 or
+            _is_nth_child_of_kind(stack, [0], CursorKind.SWITCH_STMT) != 0 or
+            _is_nth_child_of_kind(stack, [0], CursorKind.CASE_STMT) != 0 or
             FOR_POSITION.COND in _get_positions_in_for_loop(stack))
 
 
@@ -311,7 +313,9 @@ def in_condition(stack):
     """
     # In every case the first child of IF_STMT is the condition itself
     # (non-NULL) so the second and third child are in the then/else branch
-    return _is_nth_child_of_kind(stack, [1, 2], CursorKind.IF_STMT) == 1
+    return (_is_nth_child_of_kind(stack, [1, 2], CursorKind.IF_STMT) == 1 or
+            (_is_nth_child_of_kind(stack, [1], CursorKind.SWITCH_STMT) == 1 and
+             _is_nth_child_of_kind(stack, [0], CursorKind.CASE_STMT) == 0))
 
 
 def in_second_level_condition(stack):

--- a/tests/c_languages/codeclone_detection/ClangCountingConditionsTest.py
+++ b/tests/c_languages/codeclone_detection/ClangCountingConditionsTest.py
@@ -239,3 +239,21 @@ class ClangCountingConditionsTest(unittest.TestCase):
              "b": [1],
              "1": [0],
              "2": [1]})
+
+    def test_is_condition_switch(self):
+        self.check_counting_condition(
+            "is_condition",
+            (154, "switching(int, int)"),
+            {"a": [1],
+             "b": [0],
+             "2": [1],
+             "1": [1]})
+
+    def test_in_conditions_switch(self):
+        self.check_counting_condition(
+            "in_condition",
+            (154, "switching(int, int)"),
+            {"a": [2],
+             "b": [3],
+             "2": [0],
+             "1": [0]})

--- a/tests/c_languages/codeclone_detection/conditions_samples.c
+++ b/tests/c_languages/codeclone_detection/conditions_samples.c
@@ -150,3 +150,17 @@ int structing(struct test_struct a, struct test_struct *b) {
     a.a = 1 + b;
     (b+2)->a = 2;
 }
+
+int switching(int a, int b) {
+    switch (a) {
+        case 1:
+            b++;
+            return b;
+        case 2:
+            a++;
+            return b;
+        default:
+            a++
+            break;
+    }
+}


### PR DESCRIPTION
Add support for switch/case statements in ClangCodeCloneDetectionBear
as  it does not currenly support it.This would count the condition with
the Is condition CC and the bodies with the In condition CCs so nested
things are recognized right.

Fixes https://github.com/coala-analyzer/coala-bears/issues/39