### PR TITLE
Bugfix backporting to 0.1

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -60,9 +60,7 @@ class GitCommitBear(GlobalBear):
             self.err("git:", repr(stderr))
             return
 
-        # git automatically removes trailing whitespaces. Also we need to
-        # remove the last \n printed to align the prompt onto the next line.
-        stdout = stdout.splitlines()[:-1]
+        stdout = stdout.rstrip("\n").splitlines()
 
         if len(stdout) == 0:
             if not allow_empty_commit_message:

--- a/bears/xml/XMLBear.py
+++ b/bears/xml/XMLBear.py
@@ -1,3 +1,5 @@
+import itertools
+
 from coalib.bearlib.abstractions.Lint import Lint
 from coalib.bears.LocalBear import LocalBear
 from coalib.misc.Shell import escape_path_argument
@@ -22,11 +24,15 @@ class XMLBear(LocalBear, Lint):
     diff_message = "XML can be formatted better."
     output_regex = r'(.*\.xml):(?P<line>\d+): (?P<message>.*)\n.*\n.*'
     gives_corrected = True
+    use_stderr = True
 
     def process_output(self, output, filename, file):
-        if self.stdout_output:  # only yield Result if stdout is not empty
-            return self._process_corrected(self.stdout_output, filename, file)
-        if self.stderr_output:  # pragma: no cover
+        if self.stdout_output:
+            # Return issues from stderr and stdout if stdout is not empty
+            return itertools.chain(
+                self._process_issues(self.stderr_output, filename),
+                self._process_corrected(self.stdout_output, filename, file))
+        else:  # Return issues from stderr if stdout is empty
             return self._process_issues(self.stderr_output, filename)
 
     def run(self, filename, file,

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import stat
 import unittest
+import unittest.mock
 from queue import Queue
 from tempfile import mkdtemp
 
@@ -99,6 +100,12 @@ class GitCommitBearTest(unittest.TestCase):
 
         self.assertEqual(self.run_uut(allow_empty_commit_message=True),
                          [])
+        self.assertTrue(self.msg_queue.empty())
+
+    @unittest.mock.patch("bears.vcs.git.GitCommitBear.run_shell_command",
+                         return_value=("one-liner-message\n", ""))
+    def test_pure_oneliner_message(self, patch):
+        self.assertEqual(self.run_uut(), [])
         self.assertTrue(self.msg_queue.empty())
 
     def test_shortlog_checks_length(self):

--- a/tests/xml/test_files/xsd-error.xml
+++ b/tests/xml/test_files/xsd-error.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <note
   xmlns="http://www.w3schools.com"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Errors were shown as logs instead of errors. Corrected the processing of
output to show the error messages.

Fixes https://github.com/coala-analyzer/coala-bears/issues/251