### PR TITLE
Add ClangComplexityBear

### DIFF
--- a/bears/c_languages/codeclone_detection/ClangComplexityBear.py
+++ b/bears/c_languages/codeclone_detection/ClangComplexityBear.py
@@ -1,0 +1,94 @@
+from clang.cindex import Index, CursorKind
+
+from coalib.bears.LocalBear import LocalBear
+from coalib.results.Result import Result
+from coalib.results.SourceRange import SourceRange
+from bears.c_languages.ClangBear import clang_available
+
+
+class ClangComplexityBear(LocalBear):
+    """
+    Calculates cyclomatic complexity of each function and displays it to the
+    user.
+    """
+    check_prerequisites = classmethod(clang_available)
+    decisive_cursor_kinds = {
+        CursorKind.IF_STMT, CursorKind.WHILE_STMT, CursorKind.FOR_STMT,
+        CursorKind.DEFAULT_STMT, CursorKind.CASE_STMT}
+
+    def function_key_points(self, cursor, top_function_level=False):
+        """
+        Calculates number of function's decision points and exit points.
+
+        :param top_function_level: Whether cursor is in the top level of
+                                   the function.
+        """
+        decisions, exits = 0, 0
+
+        for child in cursor.get_children():
+            if child.kind in self.decisive_cursor_kinds:
+                decisions += 1
+            elif child.kind == CursorKind.RETURN_STMT:
+                exits += 1
+                if top_function_level:
+                    # There is no point to move forward, so just return.
+                    return decisions, exits
+            child_decisions, child_exits = self.function_key_points(child)
+            decisions += child_decisions
+            exits += child_exits
+
+        if top_function_level:
+            # Implicit return statement.
+            exits += 1
+
+        return decisions, exits
+
+    def complexities(self, cursor, filename):
+        """
+        Calculates cyclomatic complexities of functions.
+        """
+
+        file = cursor.location.file
+
+        if file is not None and file.name != filename:
+            # There is nothing to do in another file.
+            return
+
+        if cursor.kind == CursorKind.FUNCTION_DECL:
+            child = next((child for child in cursor.get_children()
+                          if child.kind != CursorKind.PARM_DECL),
+                         None)
+            if child:
+                decisions, exits = self.function_key_points(child, True)
+                complexity = max(1, decisions - exits + 2)
+                yield cursor, complexity
+        else:
+            for child in cursor.get_children():
+                yield from self.complexities(child, filename)
+
+    def run(self, filename, file, max_complexity: int=8):
+        """
+        Calculates cyclomatic complexity of functions in file.
+
+        :param max_complexity:  Maximum cyclomatic complexity that is
+                                considered to be normal. The value of 10 had
+                                received substantial corroborating evidence.
+                                But the general recommendation: "For each
+                                module, either limit cyclomatic complexity to
+                                [the agreed-upon limit] or provide a written
+                                explanation of why the limit was exceeded."
+        """
+
+        root = Index.create().parse(filename).cursor
+        for cursor, complexity in self.complexities(root, filename):
+            if complexity > max_complexity:
+                affected_code = (SourceRange.from_clang_range(cursor.extent),)
+                yield Result(
+                    self,
+                    "The cyclomatic complexity of function {function} is "
+                    "{complexity} which exceeded maximal recommended value "
+                    "of {rec_value}.".format(
+                        function=cursor.displayname,
+                        complexity=complexity,
+                        rec_value=max_complexity),
+                    affected_code=affected_code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Use >= for development versions so that source builds always work
-coala>=0.5.2.dev20160321212109
+coala>=0.6.0.dev20160325124842
 setuptools>=19.2
 munkres3~=1.0.5.5
 pylint~=1.5.2

--- a/tests/c_languages/codeclone_detection/ClangComplexityBearTest.py
+++ b/tests/c_languages/codeclone_detection/ClangComplexityBearTest.py
@@ -1,0 +1,91 @@
+import os
+import unittest
+from queue import Queue
+from clang.cindex import Index
+
+from coalib.settings.Section import Section
+from coalib.results.Result import Result
+from coalib.results.SourceRange import SourceRange
+from bears.c_languages.codeclone_detection.ClangComplexityBear import (
+    ClangComplexityBear)
+from tests.BearTestHelper import generate_skip_decorator
+from tests.LocalBearTestHelper import execute_bear
+
+
+@generate_skip_decorator(ClangComplexityBear)
+class ClangComplexityBearTest(unittest.TestCase):
+
+    def setUp(self):
+        self.filename = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     "conditions_samples.c"))
+        self.file = "fake"
+        self.queue = Queue()
+        self.section = Section("test section")
+        self.bear = ClangComplexityBear(self.section, self.queue)
+
+    def test_calculation(self):
+        """
+        Testing that number of decision points and exit points are calculated
+        correctly.
+        """
+        expected = [
+            ('used(int, int)', 3),
+            ('returned(int, int)', 1),
+            ('loopy(int, int)', 5),
+            ('in_condition(int, int)', 1),
+            ('assignation(int, int)', 2),
+            ('arithmetics(int, int)', 1),
+            ('levels(int, int, int)', 10),
+            ('structing(struct test_struct, struct test_struct *)', 1),
+            ('switching(int, int)', 2)]
+
+        root = Index.create().parse(self.filename).cursor
+        complexities_gen = self.bear.complexities(root, self.filename)
+        results = [(cursor.displayname, complexity)
+                   for cursor, complexity in complexities_gen]
+        self.assertSequenceEqual(results, expected)
+
+    def test_output(self):
+        """
+        Validating that the yielded results are correct.
+        """
+        affected_code = (SourceRange.from_values(
+            self.filename,
+            start_line=111,
+            start_column=1,
+            end_line=143,
+            end_column=2),)
+        expected_result = Result(
+            self.bear,
+            "The cyclomatic complexity of function levels(int, int, int) is "
+            "10 which exceeded maximal recommended value of 8.",
+            affected_code=affected_code)
+        with execute_bear(self.bear, self.filename, self.file, 8) as out:
+            self.assertEqual(len(out), 1)
+        self.assertEqual(out[0], expected_result)
+
+    def test_empty_declared_function(self):
+        """
+        Should not take into account and display empty function declarations.
+        """
+        self.filename = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     "empty_declarations.c"))
+        expected = [('with_body(int *)', 1)]
+
+        root = Index.create().parse(self.filename).cursor
+        complexities_gen = self.bear.complexities(root, self.filename)
+        results = [(cursor.displayname, complexity)
+                   for cursor, complexity in complexities_gen]
+        self.assertSequenceEqual(results, expected)
+
+    def test_file_does_not_exist(self):
+        """
+        Tests that bear throws TranslationUnitLoadError when file does not
+        exist.
+        """
+        from clang.cindex import TranslationUnitLoadError
+
+        generator = self.bear.execute("not_existing", self.file)
+        self.assertNotEqual(generator, None)
+        with self.assertRaises(TranslationUnitLoadError):
+            yield generator

--- a/tests/c_languages/codeclone_detection/empty_declarations.c
+++ b/tests/c_languages/codeclone_detection/empty_declarations.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include "not_existant.c"
+
+int wihtout_params(void);
+
+void* with_one_param(int x);
+
+char with_two_params(char*, double);
+
+int with_body(int *argc) {
+    if (argc) {
+        return 0;
+    } else {
+        return 1;
+    }
+    return 2;
+}


### PR DESCRIPTION
Fixes https://github.com/coala-analyzer/coala-bears/issues/81
But, here is still a problem. If we have:

```c
int f(int a) {
    if (a)
        return 0;
    else
        return 1;
    if (!a)
         return 2;
    else
         return 3;
}
```
statement `if (!a)` is unreachable, but I will not catch that and will have 2 decision points. In addition, I'll count 5 exit points (extra at the end of the block) instead of 2.