### PR TITLE
bears/css: Add AutoPrefixBear

### DIFF
--- a/bears/css/CSSAutoPrefixBear.py
+++ b/bears/css/CSSAutoPrefixBear.py
@@ -1,0 +1,18 @@
+from coalib.bearlib.abstractions.Lint import Lint
+from coalib.bears.LocalBear import LocalBear
+
+
+class CSSAutoPrefixBear(Lint, LocalBear):
+    executable = "postcss"
+    arguments = "--use autoprefixer {filename}"
+    prerequisite_command = ['postcss', '--use', 'autoprefixer']
+    prerequisite_fail_msg = "Autoprefixer is not installed."
+    diff_message = "Add vendor prefixes to CSS rules."
+    gives_corrected = True
+
+    def run(self, filename, file):
+        '''
+        This bear adds vendor prefixes to CSS rules using ``autoprefixer``
+        utility.
+        '''
+        return self.lint(filename, file)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "alex": "~2.0.1",
+    "autoprefixer": "~6.3.4", 
     "bootlint": "~0.14.2",
     "coffeelint": "~1.14.2",
     "complexity-report": "~2.0.0-alpha",
@@ -8,6 +9,7 @@
     "dockerfile_lint": "~0.0.9",
     "eslint": "~2.3.0",
     "jshint": "~2.9.1",
+    "postcss-cli": "~2.5.1",
     "remark": "~3.2.3",
     "tslint": "~3.5.0"
   }

--- a/tests/css/CSSAutoPrefixBearTest.py
+++ b/tests/css/CSSAutoPrefixBearTest.py
@@ -1,0 +1,22 @@
+from bears.css.CSSAutoPrefixBear import CSSAutoPrefixBear
+from tests.LocalBearTestHelper import verify_local_bear
+
+
+good_file = """
+.example {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+}
+""".splitlines(keepends=True)
+
+bad_file = """
+.example {
+    display: flex;
+}
+""".splitlines(keepends=True)
+
+CSSAutoPrefixBear = verify_local_bear(CSSAutoPrefixBear,
+                                      valid_files=(good_file,),
+                                      invalid_files=(bad_file,))


### PR DESCRIPTION
This bear uses PostCSS plugin autoprefixer to add
vendor prefixes to CSS rules.

Fixes https://github.com/coala-analyzer/coala-bears/issues/280