### PR TITLE
GitCommitBear: Add imperative check in shortlog

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -49,6 +49,10 @@ install:
   - "%CMD_IN_ENV% pip install --find-links=C:\\wheels -r test-requirements.txt"
   - "%CMD_IN_ENV% pip install --find-links=C:\\wheels -r requirements.txt"
   - "%CMD_IN_ENV% pip install --upgrade astroid"
+  # Download required nltk data
+  - "python -m nltk.downloader punkt"
+  - "python -m nltk.downloader maxent_treebank_pos_tagger"
+  - "python -m nltk.downloader averaged_perceptron_tagger"
   # Calling setup.py will download checkstyle automatically so tests may succeed
   - "%CMD_IN_ENV% python setup.py --help"
 

--- a/.ci/deps.nltk.sh
+++ b/.ci/deps.nltk.sh
@@ -1,0 +1,17 @@
+set -e
+set -x
+
+
+NLTK_DATA_PATH=~/nltk_data
+
+function download_nltk_data {
+  python -m nltk.downloader punkt
+  python -m nltk.downloader maxent_treebank_pos_tagger
+  python -m nltk.downloader averaged_perceptron_tagger
+}
+
+if [ ! -d $NLTK_DATA_PATH ]; then
+  download_nltk_data
+else
+  echo "Using cached nltk data from $NLTK_DATA_PATH"
+fi

--- a/.ci/deps.osx.sh
+++ b/.ci/deps.osx.sh
@@ -37,6 +37,9 @@ pip install -U pip
 pip install -r test-requirements.txt
 pip install -r requirements.txt
 
+# Downloading nltk data that's required for nltk to run 
+bash .ci/deps.nltk.sh
+
 # Calling setup.py will download checkstyle automatically so tests may succeed
 python setup.py --help
 

--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -57,6 +57,9 @@ done
 
 pip install -r docs-requirements.txt
 
+# Downloading nltk data that's required for nltk to run 
+bash .ci/deps.nltk.sh
+
 python setup.py --help
 
 # Dart Lint commands

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
     - ~/dart-sdk/bin
     - ~/.cabal
     - ~/infer-linux64-v0.7.0
+    - ~/nltk_data
   pre:
     - echo 'export PATH=$PATH:~/coala-bears/node_modules/.bin' >> ~/.circlerc
     - echo 'export LINTR_COMMENT_BOT=false' >> ~/.circlerc

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,6 @@ pydocstyle~=1.0.0
 cmakelint~=1.3.4
 requests_mock~=0.7.0
 vim-vint~=0.3.6
+# Stable version 3.2 is problematic in Windows.
+# Use >=3.3 once nltk-3.3 is released. 
+nltk~=3.1.0

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -109,7 +109,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertTrue(self.msg_queue.empty())
 
     def test_shortlog_checks_length(self):
-        self.git_commit("Commits messages that nearly exceeds default limit")
+        self.git_commit("Commit messages that nearly exceed default limit..")
 
         self.assertEqual(self.run_uut(), [])
         self.assertTrue(self.msg_queue.empty())
@@ -119,7 +119,7 @@ class GitCommitBearTest(unittest.TestCase):
                           "longer than the limit (50 > 17)."])
         self.assertTrue(self.msg_queue.empty())
 
-        self.git_commit("A shortlog that is too long is not good for history")
+        self.git_commit("Add a very long shortlog for a bad project history.")
         self.assertEqual(self.run_uut(),
                          ["Shortlog of HEAD commit is 1 character(s) longer "
                           "than the limit (51 > 50)."])
@@ -138,6 +138,24 @@ class GitCommitBearTest(unittest.TestCase):
             ["Shortlog of HEAD commit contains no period at end."])
         self.assertEqual(self.run_uut(shortlog_trailing_period=False), [])
         self.assertEqual(self.run_uut(shortlog_trailing_period=None), [])
+
+    def test_shortlog_checks_imperative(self):
+        self.git_commit("tag: Add shortlog in imperative")
+        self.assertNotIn("Shortlog of HEAD commit isn't imperative mood, "
+                         "bad words are 'Add'",
+                         self.run_uut())
+        self.git_commit("Added invalid shortlog")
+        self.assertIn("Shortlog of HEAD commit isn't imperative mood, "
+                      "bad words are 'Added'",
+                      self.run_uut())
+        self.git_commit("Adding another invalid shortlog")
+        self.assertIn("Shortlog of HEAD commit isn't imperative mood, "
+                      "bad words are 'Adding'",
+                      self.run_uut())
+        self.git_commit("Added another invalid shortlog")
+        self.assertNotIn("Shortlog of HEAD commit isn't imperative mood, "
+                         "bad words are 'Added'",
+                         self.run_uut(shortlog_imperative_check=False))
 
     def test_shortlog_checks_regex(self):
         pattern = ".*?: .*[^.]"
@@ -203,7 +221,7 @@ class GitCommitBearTest(unittest.TestCase):
 
     def test_different_path(self):
         no_git_dir = mkdtemp()
-        self.git_commit("A shortlog that is too long is not good for history")
+        self.git_commit("Add a very long shortlog for a bad project history.")
         os.chdir(no_git_dir)
         # When section doesn't have a config setting
         self.assertEqual(self.run_uut(), [])


### PR DESCRIPTION
This commit adds `check_imperative` method in `GitCommitBear`.
The method checks if a shortlog is in imperative mood or not.
If the shortlog isn't in imperative mood then it'd throw an error
message including the invalid words that are the cause for being non
imperative so that user could get some hint and fix his commit.

Fixes https://github.com/coala-analyzer/coala-bears/issues/243