### PR TITLE
RLintBearTest: Conform to lintr's spacing rule

### DIFF
--- a/tests/r/RLintBearTest.py
+++ b/tests/r/RLintBearTest.py
@@ -4,7 +4,7 @@ from tests.LocalBearTestHelper import verify_local_bear
 good_file = """
 fun <- function(one){
   one_plus_one <- one + 1
-  four <- matrix(1:10, nrow =2)
+  four <- matrix(1:10, nrow = 2)
   print(one_plus_one, four)
 }""".splitlines(keepends=True)
 


### PR DESCRIPTION
Previously, lintr didn't account for spaces around all infix
operators.

This commit introduces that:
https://github.com/jimhester/lintr/commit/c7eda9e370f3e5e8856e8695af477214fc428f3b

Now tests are being changed to conform to the new rule.