### PR TITLE
GitCommitBear: Divide metadata signature

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -130,7 +130,7 @@ class GitCommitBear(GlobalBear):
                 yield Result(self,
                              "This commit seems to be marked as work in "
                              "progress and should not be used in production. "
-                             "Tread carefully.", severity=RESULT_SEVERITY.MAJOR)
+                             "Treat carefully.", severity=RESULT_SEVERITY.MAJOR)
 
     def check_imperative(self, paragraph):
         """

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -127,10 +127,10 @@ class GitCommitBear(GlobalBear):
                              "bad words are '{}'".format(bad_word))
         if shortlog_wip_check:
             if "wip" in shortlog.lower()[:4]:
-                yield Result(self,
-                             "This commit seems to be marked as work in "
-                             "progress and should not be used in production. "
-                             "Treat carefully.", severity=RESULT_SEVERITY.MAJOR)
+                yield Result(
+                    self,
+                    "This commit seems to be marked as work in progress and "
+                    "should not be used in production. Treat carefully.")
 
     def check_imperative(self, paragraph):
         """

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -90,8 +90,8 @@ class GitCommitBear(GlobalBear):
         :param shortlog_trailing_period: Whether a dot shall be enforced at end
                                          end or not (or ``None`` for "don't
                                          care").
-        :param shortlog_wip_check:       Whether a wip in the shortlog should
-                                         yield a major result or not.
+        :param shortlog_wip_check:       Whether a "WIP" in the shortlog text
+                                         should yield a result or not.
         """
         diff = len(shortlog) - shortlog_length
         if diff > 0:

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -154,9 +154,9 @@ class GitCommitBearTest(unittest.TestCase):
         self.git_commit("[wip] Shortlog")
         self.assertEqual(self.run_uut(shortlog_wip_check=False), [])
         self.assertEqual(self.run_uut(shortlog_wip_check=True),
-                         ["This commit seems to be marked as work in "
-                             "progress and should not be used in production. "
-                             "Tread carefully."])
+                         ["This commit seems to be marked as work in progress "
+                          "and should not be used in production. Treat "
+                          "carefully."])
         self.assertEqual(self.run_uut(shortlog_wip_check=None), [])
         self.git_commit("Shortlog as usual")
         self.assertEqual(self.run_uut(shortlog_wip_check=True), [])

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -81,6 +81,17 @@ class GitCommitBearTest(unittest.TestCase):
         finally:
             shutil.which = _shutil_which
 
+    def test_get_metadata(self):
+        metadata = GitCommitBear.get_metadata()
+        self.assertEqual(
+            metadata.name,
+            "<Merged signature of 'run', 'check_shortlog', 'check_body'>")
+
+        # Test if at least one parameter of each signature is used.
+        self.assertIn("allow_empty_commit_message", metadata.optional_params)
+        self.assertIn("shortlog_length", metadata.optional_params)
+        self.assertIn("body_line_length", metadata.optional_params)
+
     def test_git_failure(self):
         # In this case use a reference to a non-existing commit, so just try
         # to log all commits on a newly created repository.


### PR DESCRIPTION
The metadata is now retrieved from `check_shortlog` and `check_body` to
avoid signature duplication overhead.