### PR TITLE
bears/go: Add GoErrCheckBear

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -41,6 +41,7 @@ go get -u github.com/golang/lint/golint
 go get -u golang.org/x/tools/cmd/goimports
 go get -u sourcegraph.com/sqs/goreturns
 go get -u golang.org/x/tools/cmd/gotype
+go get -u github.com/kisielk/errcheck 
 
 # Ruby commands
 bundle install

--- a/bears/go/GoErrCheckBear.py
+++ b/bears/go/GoErrCheckBear.py
@@ -1,0 +1,50 @@
+from coalib.bearlib.abstractions.Linter import linter
+from coalib.settings.Setting import typed_list
+
+
+@linter(executable='errcheck',
+        output_format='regex',
+        output_regex=r'(?P<filename>[^:]+):(?P<line>\d+):'
+                     r'(?P<col>\d+)\s*(?P<message>.*)',
+        result_message="This function call has an unchecked error.")
+class GoErrCheckBear:
+
+    """
+    Checks the code for all function calls that have unchecked errors.
+    GoErrCheckBear runs ``errcheck`` over each file to find such functions.
+
+    For more information on the analysis visit <https://github.com/kisielk/errcheck>.
+    """
+    LANGUAGES = "Go"
+
+    @staticmethod
+    def create_arguments(filename, file, config_file,
+                         ignore: typed_list(str)=[],
+                         ignorepkg: typed_list(str)=[],
+                         asserts: bool=False,
+                         blank: bool=False):
+        """
+        Bear configuration arguments.
+
+        :param ignore:       Comma-separated list of pairs of the
+                             form package:regex. For each package, the regex
+                             describes which functions to ignore within that
+                             package. The package may be omitted to have the
+                             regex apply to all packages.
+        :param ignorepkg:    Takes a comma-separated list of package
+                             import paths to ignore.
+        :param asserts:      Enables checking for ignored type assertion results
+        :param blank:        Enables checking for assignments of errors to
+                             the blank identifier.
+
+        """
+        args = ()
+        if ignore:
+            args += ('-ignore', ','.join(part.strip() for part in ignore))
+        if ignorepkg:
+            args += ('-ignorepkg', ','.join(part.strip() for part in ignorepkg))
+        if blank:
+            args += ("-blank",)
+        if asserts:
+            args += ("-asserts",)
+        return args + (filename,)

--- a/tests/go/GoErrCheckBearTest.py
+++ b/tests/go/GoErrCheckBearTest.py
@@ -1,0 +1,104 @@
+from bears.go.GoErrCheckBear import GoErrCheckBear
+from tests.LocalBearTestHelper import verify_local_bear
+
+good_file = """package main
+import "fmt"
+func main() {
+    fmt.Println("Hello, Arch!")
+}
+""".splitlines(keepends=True)
+
+
+bad_file = """package main
+import "os"
+func main() {
+f, _ := os.Open("foo")
+f.Write([]byte("Hello, world."))
+f.Close()
+}
+""".splitlines(keepends=True)
+
+assert_file = """package main
+
+func main() {
+// Type assertions
+  var i interface{}
+  s1 := i.(string)    // ASSERT
+  s1 = i.(string)     // ASSERT
+  s2, _ := i.(string) // ASSERT
+  s2, _ = i.(string)  // ASSERT
+  s3, ok := i.(string)
+  s3, ok = i.(string)
+  switch s4 := i.(type) {
+  case string:
+    _ = s4
+  }
+  _, _, _, _ = s1, s2, s3, ok
+
+}
+""".splitlines(keepends=True)
+
+blank_file = """package main
+import "os"
+import "fmt"
+
+func main() {
+f, _ := os.Open("random")
+    fmt.Println(f)
+}""".splitlines(keepends=True)
+
+ignorepkg_file = """package main
+import (
+  "io"
+  "log"
+  "os"
+)
+func main() {
+  f, _ := os.Open("foo")
+  log.Println("opened file")
+  io.Copy(os.Stdout, f)
+}""".splitlines(keepends=True)
+
+GoErrCheckBearTest = verify_local_bear(GoErrCheckBear,
+                                       valid_files=(
+                                           good_file, assert_file, blank_file),
+                                       invalid_files=(bad_file,),
+                                       tempfile_kwargs={"suffix": ".go"})
+
+GoErrCheckBearWithIgnoreTest = verify_local_bear(GoErrCheckBear,
+                                                 valid_files=(
+                                                     good_file,
+                                                     assert_file,
+                                                     blank_file),
+                                                 invalid_files=(bad_file,),
+                                                 settings={
+                                                     "ignore":
+                                                     "'[rR]ead|[wW]rite'"},
+                                                 tempfile_kwargs={"suffix":
+                                                                  ".go"})
+GoErrCheckBearWithIgnorePkgTest = verify_local_bear(GoErrCheckBear,
+                                                    valid_files=(
+                                                        good_file, assert_file,
+                                                        blank_file),
+                                                    invalid_files=(
+                                                        ignorepkg_file,),
+                                                    settings={
+                                                        "ignorepkg":
+                                                        "'io'"},
+                                                    tempfile_kwargs={"suffix":
+                                                                     ".go"})
+
+GoErrCheckBearWithBlankTest = verify_local_bear(GoErrCheckBear,
+                                                valid_files=(good_file,
+                                                             assert_file),
+                                                invalid_files=(blank_file,),
+                                                settings={"blank": True},
+                                                tempfile_kwargs={"suffix":
+                                                                 ".go"})
+GoErrCheckBearWithAssertsTest = verify_local_bear(GoErrCheckBear,
+                                                  valid_files=(good_file,
+                                                               blank_file),
+                                                  invalid_files=(assert_file,),
+                                                  settings={"asserts": True},
+                                                  tempfile_kwargs={"suffix":
+                                                                   ".go"})


### PR DESCRIPTION
Used errcheck to find function calls
that have unchecked errors in Go.

Fixes https://github.com/coala-analyzer/coala-bears/issues/31