### PR TITLE
bears: Adapt to new Linter API

### DIFF
--- a/bears/c_languages/GNUIndentBear.py
+++ b/bears/c_languages/GNUIndentBear.py
@@ -8,7 +8,7 @@ from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 @linter(executable="indent" if platform.system() != "Darwin" else "gindent",
         use_stdin=True,
         output_format='corrected',
-        diff_message="Indentation can be improved.")
+        result_message="Indentation can be improved.")
 class GNUIndentBear:
     """
     This bear checks and corrects spacing and indentation via the well known

--- a/bears/css/CSSAutoPrefixBear.py
+++ b/bears/css/CSSAutoPrefixBear.py
@@ -3,7 +3,7 @@ from coalib.bearlib.abstractions.Linter import linter
 
 @linter(executable='postcss',
         output_format='corrected',
-        diff_message='Add vendor prefixes to CSS rules.',
+        result_message='Add vendor prefixes to CSS rules.',
         prerequisite_check_command=('postcss', '--use', 'autoprefixer'),
         prerequisite_check_fail_message='Autoprefixer is not installed.')
 class CSSAutoPrefixBear:

--- a/bears/go/GoImportsBear.py
+++ b/bears/go/GoImportsBear.py
@@ -4,7 +4,7 @@ from coalib.bearlib.abstractions.Linter import linter
 @linter(executable='goimports',
         use_stdin=True,
         output_format='corrected',
-        diff_message='Imports need to be added/removed.')
+        result_message='Imports need to be added/removed.')
 class GoImportsBear:
     """
     Adds/Removes imports to Go code for missing imports.

--- a/bears/go/GoReturnsBear.py
+++ b/bears/go/GoReturnsBear.py
@@ -4,7 +4,7 @@ from coalib.bearlib.abstractions.Linter import linter
 @linter(executable='goreturns',
         use_stdin=True,
         output_format='corrected',
-        diff_message='Imports or returns need to be added/removed.')
+        result_message='Imports or returns need to be added/removed.')
 class GoReturnsBear:
     """
     Proposes corrections of Go code using ``goreturns``.

--- a/bears/go/GofmtBear.py
+++ b/bears/go/GofmtBear.py
@@ -4,7 +4,7 @@ from coalib.bearlib.abstractions.Linter import linter
 @linter(executable='gofmt',
         use_stdin=True,
         output_format='corrected',
-        diff_message='Formatting can be improved.')
+        result_message='Formatting can be improved.')
 class GofmtBear:
     """
     Suggest better formatting options in Go code. Basic checks like alignment,

--- a/bears/markdown/MarkdownBear.py
+++ b/bears/markdown/MarkdownBear.py
@@ -6,7 +6,7 @@ from coalib.bearlib.abstractions.Linter import linter
 @linter(executable='remark',
         use_stdin=True,
         output_format='corrected',
-        diff_message='The text does not comply to the set style.')
+        result_message='The text does not comply to the set style.')
 class MarkdownBear:
     """
     Check and correct Markdown style violations automatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Use >= for development versions so that source builds always work
-coala>=0.7.0.dev20160515181430
+coala>=0.7.0.dev20160518085900
 setuptools>=19.2
 munkres3~=1.0.5.5
 pylint~=1.5.2


### PR DESCRIPTION
Due to API changes, calling it Linter v2.1 API, we need to adapt.