### PR TITLE
README.rst: Remove OSX section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ work properly.)
 Project Status
 --------------
 
-|Linux Build Status| |Windows Build status| |OSX Build status|
+|Linux Build Status| |Windows Build status|
 
 |Documentation Status| |codecov.io|
 


### PR DESCRIPTION
It is no longer used.

Fixes https://github.com/coala-analyzer/coala/issues/2148