### PR TITLE
setup.py: Change Environment classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
           classifiers=[
               'Development Status :: 4 - Beta',
 
-              'Environment :: Console',
+              'Environment :: Plugins',
               'Environment :: MacOS X',
               'Environment :: Win32 (MS Windows)',
               'Environment :: X11 Applications :: Gnome',


### PR DESCRIPTION
Here Environment classifier changes to 'Plugins' from 'Console'.
Environment :: Console -> Environment :: Plugins

Fixes https://github.com/coala-analyzer/coala-bears/issues/449