### PR TITLE
bears/general: Add IndentationBear

### DIFF
--- a/bears/general/IndentationBear.py
+++ b/bears/general/IndentationBear.py
@@ -18,7 +18,8 @@ class IndentationBear(LocalBear):
             dependency_results: dict,
             language: str,
             use_spaces: bool=True,
-            tab_width: int=4):
+            tab_width: int=4,
+            coalang_dir: str=None):
         """
         It is a generic indent bear, which looks for a start and end
         indent specifier, example: ``{ : }`` where "{" is the start indent
@@ -46,8 +47,12 @@ class IndentationBear(LocalBear):
         :param tab_width:
             No. of spaces to insert for indentation.
             Only Applicable if use_spaces is False.
+        :param coalang_dir:
+            Full path of external directory containing the coalang
+            file for language.
         """
-        lang_settings_dict = LanguageDefinition(language)
+        lang_settings_dict = LanguageDefinition(
+            language, coalang_dir=coalang_dir)
         annotation_dict = dependency_results[AnnotationBear.name][0].contents
         indent_types = dict(lang_settings_dict["indent_types"])
 

--- a/bears/general/IndentationBear.py
+++ b/bears/general/IndentationBear.py
@@ -1,0 +1,219 @@
+from coalib.bears.LocalBear import LocalBear
+from coalib.parsing.StringProcessing.Core import unescaped_search_for
+from coalib.bearlib.languages.LanguageDefinition import LanguageDefinition
+from coalib.results.SourceRange import SourceRange
+from coalib.results.Result import Result, RESULT_SEVERITY
+from coalib.results.AbsolutePosition import AbsolutePosition
+from coalib.results.Diff import Diff
+
+from bears.general.AnnotationBear import AnnotationBear
+from bears.general.AnnotationBear import starts_within_ranges
+
+
+class IndentationBear(LocalBear):
+
+    def run(self,
+            filename,
+            file,
+            dependency_results: dict,
+            language: str,
+            use_spaces: bool=True,
+            tab_width: int=4):
+        """
+        It is a generic indent bear, which looks for a start and end
+        indent specifier, example: ``{ : }`` where "{" is the start indent
+        specifier and "}" is the end indent specifier.
+
+        It does not however support hanging indents or absolute indents of
+        any sort, also indents based on keywords are not supported yet.
+        for example:
+
+            if(something)
+            does not get indented
+
+        undergoes no change.
+
+        :param filename:
+            Name of the file that needs to be checked.
+        :param file:
+            File that needs to be checked in the form of a list of strings.
+        :param dependency_results:
+            Results given by the AnnotationBear.
+        :param language:
+            Language to be used for indentation.
+        :param use_spaces:
+            Insert spaces instead of tabs for indentation.
+        :param tab_width:
+            No. of spaces to insert for indentation.
+            Only Applicable if use_spaces is False.
+        """
+        lang_settings_dict = LanguageDefinition(language)
+        annotation_dict = dependency_results[AnnotationBear.name][0].contents
+        indent_types = dict(lang_settings_dict["indent_types"])
+
+        try:
+            indent_levels = self.get_indent_levels(
+                                  file, filename, indent_types, annotation_dict)
+        # This happens only in case of unmatched indents.
+        except UnmatchedIndentError as e:
+            yield Result(self, str(e), severity=RESULT_SEVERITY.MAJOR)
+            return
+
+        insert = ' '*tab_width if use_spaces else '\t'
+        new_file = []
+        for line_nr, line in enumerate(file):
+            # Leave out empty lines
+            if line.lstrip() != '':
+                new_file.append(insert*indent_levels[line_nr] +
+                                line.lstrip())
+            else:
+                new_file.append('\n')
+
+        if new_file != list(file):
+            wholediff = Diff.from_string_arrays(file, new_file)
+            for diff in wholediff.split_diff():
+                yield Result(
+                    self,
+                    'The indentation could be changed to improve readability.',
+                    severity=RESULT_SEVERITY.INFO,
+                    affected_code=(diff.range(filename),),
+                    diffs={filename: diff})
+
+    def get_indent_levels(self, file, filename, indent_types, annotation_dict):
+        """
+        Gets the level of indentation of each line.
+
+        :param file:            File that needs to be checked in the form of
+                                a list of strings.
+        :param filename:        Name of the file that needs to be checked.
+        :param indent_types:    A dictionary with keys as start of indent and
+                                values as their corresponding closing indents.
+        :param annotation_dict: A dictionary containing sourceranges of all the
+                                strings and comments within a file.
+        :return:                A tuple containing the levels of indentation of
+                                each line.
+        """
+        indent_levels = []
+        ranges = self.get_specified_block_range(
+                         file, filename, indent_types, annotation_dict)
+        indent, next_indent = 0, 0
+        for line in range(0, len(file)):
+            indent = next_indent
+            for _range in ranges:
+                if _range.start.line == line + 1:
+                    next_indent += 1
+                if(_range.end.line == line + 1 and
+                   (file[line].lstrip()[0] in indent_types.values())):
+                    indent -= 1
+                    next_indent -= 1
+                elif _range.end.line == line + 1:
+                    next_indent -= 1
+            indent_levels.append(indent)
+
+        return tuple(indent_levels)
+
+    def get_specified_block_range(self,
+                                  file,
+                                  filename,
+                                  indent_types,
+                                  annotation_dict):
+        """
+        Gets a sourceranges of all the indentation blocks present inside the
+        file.
+
+        :param file:            File that needs to be checked in the form of
+                                a list of strings.
+        :param filename:        Name of the file that needs to be checked.
+        :param indent_types:    A dictionary with keys as start of indent and
+                                values as their corresponding closing indents.
+        :param annotation_dict: A dictionary containing sourceranges of all the
+                                strings and comments within a file.
+        :return:                A tuple whith the first source range being
+                                the range of the outermost indentation while
+                                last being the range of the most
+                                nested/innermost indentation.
+                                Equal level indents appear in the order of
+                                first encounter or left to right.
+        """
+        ranges = []
+        for open_indent in indent_types:
+            close_indent = indent_types[open_indent]
+            open_pos = list(self.get_valid_sequences(
+                                     file, open_indent, annotation_dict))
+            close_pos = list(self.get_valid_sequences(
+                                     file, close_indent, annotation_dict))
+
+            to_match = len(open_pos) - 1
+            while to_match >= 0:
+                close_index = 0
+                while close_index < len(close_pos):
+                    if(open_pos[to_match].position
+                       <= close_pos[close_index].position):
+                        ranges.append(
+                            SourceRange.from_absolute_position(
+                                            filename,
+                                            open_pos[to_match],
+                                            close_pos[close_index]))
+                        close_pos.remove(close_pos[close_index])
+                        open_pos.remove(open_pos[to_match])
+                        to_match -= 1
+                        break
+                    close_index += 1
+                if((len(close_pos) == 0 and to_match != -1) or
+                   (len(close_pos) != 0 and to_match == -1)):
+                    # None to specify unmatched indents
+                    raise UnmatchedIndentError(open_indent, close_indent)
+
+        # Ranges are returned in the order of least nested to most nested
+        # and also on the basis of which come first
+        return tuple(ranges)[::-1]
+
+    @staticmethod
+    def get_valid_sequences(file, sequence, annotation_dict):
+        """
+        A vaild sequence is a sequence that is outside of comments or strings.
+
+        :param file:            File that needs to be checked in the form of
+                                a list of strings.
+        :param sequence:        Sequence whose validity is to be checked.
+        :param annotation_dict: A dictionary containing sourceranges of all the
+                                strings and comments within a file.
+        :return:                A tuple of AbsolutePosition's of all occurances
+                                of sequence outside of string's and comments.
+        """
+        file_string = ''.join(file)
+        # tuple since order is important
+        sequence_positions = tuple()
+
+        for sequence_match in unescaped_search_for(sequence, file_string):
+            valid = True
+            sequence_position = AbsolutePosition(
+                                    file, sequence_match.start())
+
+            # ignore if within string
+            for string in annotation_dict['strings']:
+                if(sequence_position >= string.start and
+                   sequence_position <= string.end):
+                    valid = False
+
+            # ignore if within comments
+            for comment in annotation_dict['comments']:
+                if(sequence_position >= comment.start and
+                   sequence_position <= comment.end):
+                    valid = False
+
+            if valid:
+                sequence_positions += (sequence_position,)
+
+        return sequence_positions
+
+    @staticmethod
+    def get_dependencies():
+        return [AnnotationBear]  # pragma: no cover
+
+
+class UnmatchedIndentError(Exception):
+
+    def __init__(self, open_indent, close_indent):
+        Exception.__init__(self, "Unmatched " + open_indent + ", " +
+                           close_indent + " pair")

--- a/tests/general/IndentationBearTest.py
+++ b/tests/general/IndentationBearTest.py
@@ -1,0 +1,153 @@
+import unittest
+from queue import Queue
+
+from bears.general.IndentationBear import IndentationBear
+from bears.general.AnnotationBear import AnnotationBear
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+
+
+class IndentationBearTest(unittest.TestCase):
+
+    def setUp(self):
+        self.section = Section("")
+        self.section.append(Setting('language', 'c'))
+        self.section.append(Setting('use_spaces', False))
+        self.dep_uut = AnnotationBear(self.section, Queue())
+
+    def get_results(self, file, section=None):
+        if section is None:
+            section = self.section
+        dep_results_valid = self.dep_uut.execute("file", file)
+        uut = IndentationBear(section, Queue())
+        arg_dict = {'dependency_results':
+                    {AnnotationBear.__name__:
+                     list(dep_results_valid)},
+                    'file': file}
+        return list(uut.run_bear_from_section(["file"], arg_dict))
+
+    def verify_bear(self,
+                    valid_file=None,
+                    invalid_file=None,
+                    section=None):
+        if valid_file:
+            valid_results = self.get_results(valid_file, section)
+            self.assertEqual(valid_results, [])
+
+        if invalid_file:
+            invalid_results = self.get_results(invalid_file, section)
+            self.assertNotEqual(invalid_results, [])
+
+    def test_basic_indent(self):
+        valid_file =\
+            ("{\n",
+             "\tright indent\n",
+             "}\n")
+        invalid_file =\
+            ("{\n",
+             "wrong indent\n",
+             "}\n")
+        self.verify_bear(valid_file, invalid_file)
+
+        valid_file2 =\
+            ("a {\n",
+             "\tindent1\n",
+             "\tindent2\n",
+             "}\n")
+
+        invalid_file2 =\
+            ("a {\n",
+             "\tindentlevel1;\n",
+             "\t\tsecondlinehere;\n",
+             "}\n")
+        self.verify_bear(valid_file2, invalid_file2)
+
+    def test_within_strings(self):
+        valid_file1 =\
+            ('"indent specifier within string{"\n',
+             'does not indent\n')
+        self.verify_bear(valid_file1)
+
+        valid_file2 =\
+            ('R("strings can span\n',
+             'multiple lines as well{")\n'
+             'but the bear works correctly\n')
+        self.verify_bear(valid_file2)
+
+        valid_file3 =\
+            ('"this should indent"{ "hopefully"\n',
+             '\tand it does\n',
+             '}\n')
+        self.verify_bear(valid_file3)
+
+    def test_within_comments(self):
+        valid_file1 =\
+            ('//indent specifier within comments{\n',
+             'remains unindented\n')
+        self.verify_bear(valid_file1)
+
+        valid_file2 =\
+            ('/*Indent specifier within\n',
+             'lines of multiline comment {\n',
+             'doesnt have any effect{ */\n',
+             'no affect on regular lines as well\n')
+        self.verify_bear(valid_file2)
+
+        valid_file3 =\
+            ('/*this should indent*/{ /*hopefully*/\n',
+             '\tand it does\n',
+             '}\n')
+        self.verify_bear(valid_file3)
+
+    def test_branch_indents(self):
+        valid_file =\
+            ('branch indents{\n',
+             '\tsecond branch{\n',
+             '\t\twithin second branch\n',
+             '\t}\n',
+             '}\n',)
+        self.verify_bear(valid_file)
+
+    def test_bracket_matching(self):
+        valid_file = ("{{{}{}}",
+                      "\tone_indent",
+                      "}")
+        invalid_file = ("{{{}{}}",
+                        "didn't give indent",
+                        "}")
+        self.verify_bear(valid_file, invalid_file)
+
+    def test_blank_lines(self):
+        valid_file = ("{ trying indent",
+                      "\n",
+                      "\tIndents even after blank line}")
+        invalid_file = ("{ trying indent",
+                        "\n",
+                        "should've Indented after blank line}")
+        self.verify_bear(valid_file, invalid_file)
+
+    def test_settings(self):
+        section = Section("")
+        section.append(Setting('language', 'c'))
+        section.append(Setting('use_spaces', True))
+        section.append(Setting('tab_width', 6))
+        valid_file = ('{\n',
+                      # Start ignoring SpaceConsistencyBear
+                      '      6 spaces of indentation\n'
+                      # Stop ignoring
+                      '}\n')
+
+        invalid_file = ('{\n',
+                        # Start ignoring SpaceConsistencyBearW
+                        '    4 spaces of indentation\n'
+                        # Stop ignoring
+                        '}\n')
+        self.verify_bear(valid_file, invalid_file, section)
+
+    def test_unmatched_indents(self):
+        valid_file = ('{}\n',)
+        invalid_file = ('{\n',)
+        self.verify_bear(valid_file, invalid_file)
+
+        invalid_file2 = ('{}}\n',)
+        self.verify_bear(valid_file=None, invalid_file=invalid_file2)

--- a/tests/general/IndentationBearTest.py
+++ b/tests/general/IndentationBearTest.py
@@ -166,3 +166,47 @@ class IndentationBearTest(unittest.TestCase):
                         '\t<\n',
                         '\t not giving indentation>}\n')
         self.verify_bear(valid_file, invalid_file)
+
+    def test_unspecified_unindents(self):
+        valid_file = ('switch(expression) {\n',
+                      '\tcase constant-expression  :\n',
+                      '\t\tstatement(s);\n',
+                      '\t\tbreak;\n',
+                      '\tcase constant-expression  :\n',
+                      '\t\tstatement(s);\n',
+                      '\t\tbreak;\n',
+                      '\tdefault :\n',
+                      '\t\tstatement(s);\n',
+                      '}\n')
+        invalid_file = ('switch(expression){\n',
+                        '\tcase expr:\n',
+                        '\tstatement(s);\n',
+                        '}')
+        self.verify_bear(valid_file, invalid_file)
+
+        valid_file = ('def func(x,\n',
+                      # TODO correct indentation of test after support for
+                      # absolute indentation
+                      'y,\n',
+                      'z):\n',
+                      '\tsome line\n',
+                      '\tsome line 2\n')
+        invalid_file = ('def func(x):\n',
+                        '\t\tsome line\n',
+                        '\tsome line\n')
+        self.verify_bear(valid_file, invalid_file)
+
+        invalid_file = ('def func(x):\n',
+                        '\tline 1\n',
+                        '# A comment')
+        self.verify_bear(invalid_file=invalid_file)
+
+        invalid_file = ('def func(x):\n',
+                        '\ta = [1, 2,\n',
+                        '3, 4]\n')
+        self.verify_bear(invalid_file=invalid_file)
+
+        invalid_file = ('def func(x):\n',
+                        '\t/* multiline comment\n',
+                        'unindent*/')
+        self.verify_bear(invalid_file=invalid_file)

--- a/tests/general/IndentationBearTest.py
+++ b/tests/general/IndentationBearTest.py
@@ -1,18 +1,22 @@
 import unittest
 from queue import Queue
+import os
 
 from bears.general.IndentationBear import IndentationBear
 from bears.general.AnnotationBear import AnnotationBear
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
+from coalib.parsing.StringProcessing.Core import escape
 
 
 class IndentationBearTest(unittest.TestCase):
 
     def setUp(self):
         self.section = Section("")
-        self.section.append(Setting('language', 'c'))
+        self.section.append(Setting('language', 'test'))
         self.section.append(Setting('use_spaces', False))
+        self.section.append(Setting('coalang_dir', escape(os.path.join(
+            os.path.dirname(__file__), "test_files"), '\\')))
         self.dep_uut = AnnotationBear(self.section, Queue())
 
     def get_results(self, file, section=None):
@@ -151,3 +155,14 @@ class IndentationBearTest(unittest.TestCase):
 
         invalid_file2 = ('{}}\n',)
         self.verify_bear(valid_file=None, invalid_file=invalid_file2)
+
+    def test_multiple_indent_specifiers(self):
+        valid_file = ('{<\n',
+                      '\t\tdouble indents\n',
+                      '\t>\n',
+                      '\tother specifier closes\n',
+                      '}\n')
+        invalid_file = ('{\n',
+                        '\t<\n',
+                        '\t not giving indentation>}\n')
+        self.verify_bear(valid_file, invalid_file)

--- a/tests/general/test_files/test.coalang
+++ b/tests/general/test_files/test.coalang
@@ -2,3 +2,4 @@ string_delimiters = " : " , ' : '
 multiline_string_delimiters = """ : """, R(" : ")
 multiline_comment_delimiters = /* : */
 comment_delimiter = //, #
+indent_types = { : }, < : >

--- a/tests/general/test_files/test.coalang
+++ b/tests/general/test_files/test.coalang
@@ -1,5 +1,6 @@
 string_delimiters = " : " , ' : '
 multiline_string_delimiters = """ : """, R(" : ")
 multiline_comment_delimiters = /* : */
-comment_delimiter = //, #
-indent_types = { : }, < : >
+comment_delimiter = //, \#
+indent_types = { : }, < : >, :
+encapsulators = ( : ), [ : ]


### PR DESCRIPTION
It is a generic indent bear, which looks for a start and end
indent eg: { : }  if they are specified.
eg: "{"  where { is an
indent start.

it does not however support hanging indents or absolute indents of
any sort, also indents based on keywords are not supported yet.
for example:

    if(something)
    does not get indented

changes to:

    if(something)
    does not get indented

Fixes https://github.com/coala-analyzer/coala-bears/issues/40