### PR TITLE
AnnotationBear: Allow external coalang

### DIFF
--- a/bears/general/AnnotationBear.py
+++ b/bears/general/AnnotationBear.py
@@ -9,7 +9,7 @@ from coalib.results.AbsolutePosition import AbsolutePosition
 
 class AnnotationBear(LocalBear):
 
-    def run(self, filename, file, language: str):
+    def run(self, filename, file, language: str, coalang_dir: str = None):
         """
         Finds out all the positions of strings and comments in a file.
         The Bear searches for valid comments and strings and yields their
@@ -17,13 +17,14 @@ class AnnotationBear(LocalBear):
 
         :param language:        Language to be whose annotations are to be
                                 searched.
+        :param coalang_dir:     external directory for coalang file.
         :return:                HiddenResults containing a dictionary with
                                 keys as 'strings' or 'comments' and values as
                                 a tuple of SourceRanges of strings and
                                 a tuple of SourceRanges of comments
                                 respectively.
         """
-        lang_dict = LanguageDefinition(language)
+        lang_dict = LanguageDefinition(language, coalang_dir=coalang_dir)
         # Strings
         # TODO treat single-line and multiline strings differently
         strings = dict(lang_dict["string_delimiters"])

--- a/tests/general/AnnotationBearTest.py
+++ b/tests/general/AnnotationBearTest.py
@@ -1,5 +1,6 @@
 from queue import Queue
 import unittest
+import os
 
 from bears.general.AnnotationBear import AnnotationBear
 from coalib.results.SourceRange import SourceRange
@@ -7,6 +8,7 @@ from coalib.results.AbsolutePosition import AbsolutePosition
 from coalib. results.HiddenResult import HiddenResult
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
+from coalib.parsing.StringProcessing.Core import escape
 from tests.LocalBearTestHelper import execute_bear
 
 
@@ -112,3 +114,13 @@ class AnnotationBearTest(unittest.TestCase):
             self.assertIn(string2, results[0].contents['strings'])
             self.assertIn(string3, results[0].contents['strings'])
             self.assertEqual(results[0].contents['comments'], ())
+
+    def test_external_coalang(self):
+        self.section1.append(Setting('coalang_dir', escape(os.path.join(
+                            os.path.dirname(__file__), 'test_files'), '\\')))
+        self.section1.append(Setting('language', 'test'))
+        uut = AnnotationBear(self.section1, Queue())
+        text = ['//comment line 1\n', '"""string line 2"""']
+        with execute_bear(uut, "F", text) as result:
+            self.assertNotEqual(result[0].contents['strings'], ())
+            self.assertNotEqual(result[0].contents['comments'], ())

--- a/tests/general/test_files/test.coalang
+++ b/tests/general/test_files/test.coalang
@@ -1,0 +1,4 @@
+string_delimiters = " : " , ' : '
+multiline_string_delimiters = """ : """, R(" : ")
+multiline_comment_delimiters = /* : */
+comment_delimiter = //, #


### PR DESCRIPTION
coala has a new external coalang feature, which is
useful for testing and also gives users an option to use their own
coalang files.