### PR TITLE
JuliaLintBear: Use display() to print result

### DIFF
--- a/bears/julia/JuliaLintBear.py
+++ b/bears/julia/JuliaLintBear.py
@@ -32,6 +32,6 @@ class JuliaLintBear:
 
     @staticmethod
     def create_arguments(filename, file, config_file):
-        lintcode = ('import Lint.lintfile; lintfile("' +
-                    escape(filename, '"\\') + '")')
+        lintcode = ('import Lint.lintfile; display(lintfile("' +
+                    escape(filename, '"\\') + '"))')
         return '-e', lintcode


### PR DESCRIPTION
A LintResult is now returned, instead of printing it. This has
to be displayed.

https://github.com/tonyhffong/Lint.jl/commit/79c647