### PR TITLE
Make ESLint great again

### DIFF
--- a/bears/js/ESLintBear.py
+++ b/bears/js/ESLintBear.py
@@ -40,6 +40,9 @@ class ESLintBear:
         return args
 
     def process_output(self, output, filename, file):
+        if not file:
+            return
+
         output = json.loads(output)
         lines = "".join(file)
 

--- a/bears/js/ESLintBear.py
+++ b/bears/js/ESLintBear.py
@@ -30,14 +30,22 @@ class ESLintBear:
 
     @staticmethod
     def create_arguments(filename, file, config_file,
-                         eslint_config: str=""):
+                         eslint_config: str=''):
         """
         :param eslint_config: The location of the .eslintrc config file.
         """
         args = '--no-ignore', '--no-color', '-f=json', '--stdin'
+        if config_file and (not eslint_config):
+            args += ('--config', config_file)
+
         if eslint_config:
             args += ('--config', eslint_config)
+
         return args
+
+    @staticmethod
+    def generate_config(filename, file):
+        return '{"extends": "eslint:recommended"}'
 
     def process_output(self, output, filename, file):
         if not file:

--- a/tests/js/ESLintBearTest.py
+++ b/tests/js/ESLintBearTest.py
@@ -26,16 +26,21 @@ test_bad = """function addOne(i) {
 
 test_syntax_error = ('{<!@3@^ yeah!/\n',)
 
+test_empty_file = ()
+
 eslintconfig = os.path.join(os.path.dirname(__file__),
                             "test_files",
                             "eslintconfig.json")
 
 ESLintBearTestWithConfig = verify_local_bear(ESLintBear,
-                                             valid_files=(test_good,),
+                                             valid_files=(
+                                                 test_good, test_empty_file),
                                              invalid_files=(test_bad,),
                                              settings={"eslint_config":
                                                        eslintconfig})
 
 ESLintBearWithoutConfig = verify_local_bear(ESLintBear,
-                                            valid_files=(test_good, test_bad),
-                                            invalid_files=(test_syntax_error,))
+                                            valid_files=(
+                                                test_good, test_bad, test_empty_file),
+                                            invalid_files=(
+                                                test_syntax_error, test_bad))

--- a/tests/js/ESLintBearTest.py
+++ b/tests/js/ESLintBearTest.py
@@ -41,6 +41,6 @@ ESLintBearTestWithConfig = verify_local_bear(ESLintBear,
 
 ESLintBearWithoutConfig = verify_local_bear(ESLintBear,
                                             valid_files=(
-                                                test_good, test_bad, test_empty_file),
+                                                test_good, test_empty_file),
                                             invalid_files=(
                                                 test_syntax_error, test_bad))


### PR DESCRIPTION
Some background behind the rationale:

## Tests

- Why are `test_empty_files` an empty tuple? Because coala seems to use `readlines` and I suppose that it returns an empty tuple rather than a `('',)` which makes sense somehow, fixing this in the coala core might not be a good idea.

- Why do you put the `test_bad` from WithoutConfig test in the `bad` field instead of `good`? Because, the defaults says that this is bad even without config! Better safe than sorry! The auto-generated configuration derives from the recommended one of ESLint. This configuration indicates that the `test_bad` stays **bad**.

## Early return

Why would we bother parsing an empty string?
In fact, ESLint returns a JSON in case of empty file. But if you use `stdin`, there is no way to get a JSON result, you will get the help text (not JSON but not empty).

So the check have to be on the content of the file.