### PR TITLE
package.json: Add name and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "coala-bears",
+  "version":"0.8.0",
   "dependencies": {
     "alex": "~2",
     "autoprefixer": "~6",


### PR DESCRIPTION
Add ``name`` and ``version`` fields
so that ``npm install`` doesn't fails.

Fixes https://github.com/coala-analyzer/coala-bears/issues/642