### PR TITLE
CPDBear: Fix typo omparison to comparison

### DIFF
--- a/bears/general/CPDBear.py
+++ b/bears/general/CPDBear.py
@@ -72,7 +72,7 @@ class CPDBear(GlobalBear):
             Ignore ``using`` directives in C#.
         :param skip_duplicate_files:
             Ignore multiple copies of files of the same name and length in
-            omparison.
+            comparison.
         """
         language = language.lower()
 


### PR DESCRIPTION
Fixed the typo.

Closes https://github.com/coala-analyzer/coala-bears/issues/606