### PR TITLE
Add Pygments for reSTLintBear

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ nltk==3.1.*
 appdirs==1.*
 pyyaml==3.*
 vulture==0.10.*
+Pygments==2.1.*


### PR DESCRIPTION
reSTLintBear requires Pygments package to
analyze code.

Fixes https://github.com/coala-analyzer/coala-bears/issues/671