### PR TITLE
Bump NLTK version to 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ cmakelint==1.*
 vim-vint==0.3.*
 # Stable version 3.2 is problematic in Windows.
 # Use >=3.3,==3.* once nltk-3.3 is released.
-nltk==3.1.*
+nltk==3.2.*
 appdirs==1.*
 pyyaml==3.*
 vulture==0.10.*


### PR DESCRIPTION
We were holding off on this version bump because of a bug in 3.2, but
this issue has now been fixed in 3.2.1, and the buggy version was
removed from PyPI.

Closes https://github.com/coala-analyzer/coala-bears/issues/509