### PR TITLE
CSecurityBear: Remove neverignore from settings

### DIFF
--- a/bears/c_languages/CSecurityBear.py
+++ b/bears/c_languages/CSecurityBear.py
@@ -33,12 +33,5 @@ class CSecurityBear:
     CAN_DETECT = {'Security', 'Memory Leak', 'Code Simplification'}
 
     @staticmethod
-    def create_arguments(filename, file, config_file, neverignore: bool=False):
-        """
-        :param neverignore:
-            Never ignore security issues, even if they have an ``ignore``
-            directive in a comment.
-        """
-        args = "--columns", "--dataonly", "--quiet", "--singleline"
-        args += ("--neverignore", filename) if neverignore else (filename,)
-        return args
+    def create_arguments(filename, file, config_file):
+        return "--columns", "--dataonly", "--quiet", "--singleline", filename

--- a/tests/c_languages/CSecurityBearTest.py
+++ b/tests/c_languages/CSecurityBearTest.py
@@ -20,21 +20,7 @@ if ((len = readlink("/modules/pass1", buf, sizeof(buf)-1)) != -1)
 """
 
 
-good_file1 = """
-void demo(char *a) {
-    strcpy(a, 'c');  // Flawfinder: ignore
-}"""
-
-
 CSecurityBearTest = verify_local_bear(
     CSecurityBear,
     valid_files=(good_file,),
-    invalid_files=(bad_file1, bad_file2, good_file1),
-    settings={"neverignore": "true"})
-
-
-CSecurityBearIgnoreTest = verify_local_bear(
-    CSecurityBear,
-    valid_files=(good_file1, good_file),
-    invalid_files=(bad_file2,),
-    settings={"neverignore": "false"})
+    invalid_files=(bad_file1, bad_file2,))


### PR DESCRIPTION
Remove `neverignore` setting from the bear as this should not be done by the bear.

Fixes https://github.com/coala-analyzer/coala-bears/issues/680