### PR TITLE
YapfBear: Disable syntax verification

### DIFF
--- a/bears/python/YapfBear.py
+++ b/bears/python/YapfBear.py
@@ -142,7 +142,8 @@ space_between_ending_comma_and_closing_bracket= \
         with prepare_file(options.splitlines(keepends=True),
                           None) as (file_, fname):
             corrected = FormatFile(filename,
-                                   style_config=fname)[0].splitlines(True)
+                                   style_config=fname,
+                                   verify=False)[0].splitlines(True)
         diffs = Diff.from_string_arrays(file, corrected).split_diff()
         for diff in diffs:
             yield Result(self,

--- a/tests/python/YapfBearTest.py
+++ b/tests/python/YapfBearTest.py
@@ -1,4 +1,6 @@
+import sys
 from queue import Queue
+from unittest.case import skipIf
 
 from bears.python.YapfBear import YapfBear
 from tests.LocalBearTestHelper import LocalBearTestHelper
@@ -21,6 +23,15 @@ class YapfBearTest(LocalBearTestHelper):
         self.check_validity(self.uut,
                             ["x = {  'a':37,'b':42,\n", "'c':927}\n", '\n',
                              "y = 'hello ''world'\n"], valid=False)
+
+    def test_valid_python_2(self):
+        self.check_validity(self.uut, ['print 1\n'], valid=True)
+
+    @skipIf(sys.version_info < (3, 5), "ast before 3.5 can't parse async def")
+    def test_valid_async(self):
+        self.check_validity(self.uut,
+                            ['async def x():\n', '    pass\n'],
+                            valid=True)
 
     def test_blank_line_after_nested_class_or_def(self):
         self.section.append(Setting('blank_line_before_nested_class_or_def',


### PR DESCRIPTION
Syntax verification is supposed to be a private feature in yapf, used for debugging, but they're still defaulting its flag to True on the public FormatFile function. We need to set it to False to disable syntax error checking in yapf (which seems to be an unmaintained feature of it, since it raises exceptions on async/await and py2 print syntax), see discussion at https://github.com/google/yapf/issues/293

Fixes https://github.com/coala-analyzer/coala-bears/issues/738

Also filed an upstream issue here https://github.com/google/yapf/issues/297