### PR TITLE
InvalidLinkBear: Add follow_redirects setting

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -54,7 +54,8 @@ class InvalidLinkBear(LocalBear):
 
     def run(self, filename, file,
             timeout: int=DEFAULT_TIMEOUT,
-            ignore_regex: str="([.\/]example\.com|\{|\$)"):
+            ignore_regex: str="([.\/]example\.com|\{|\$)",
+            follow_redirects: bool=False):
         """
         Find links in any text file and check if they are valid.
 
@@ -69,8 +70,9 @@ class InvalidLinkBear(LocalBear):
         `do_not_ever_open = 'https://api.acme.inc/delete-all-data'` wiping out
         all your data.
 
-        :param timeout:      Request timeout period.
-        :param ignore_regex: A regex for urls to ignore.
+        :param timeout:          Request timeout period.
+        :param ignore_regex:     A regex for urls to ignore.
+        :param follow_redirects: Set to true to autocorrect redirects.
         """
         for line_number, link, code in InvalidLinkBear.find_links_in_file(
                 file, timeout, ignore_regex):
@@ -93,7 +95,7 @@ class InvalidLinkBear(LocalBear):
                         file=filename,
                         line=line_number,
                         severity=RESULT_SEVERITY.NORMAL)
-                if 300 <= code < 400:  # HTTP status 30x
+                if follow_redirects and 300 <= code < 400:  # HTTP status 30x
                     redirect_url = requests.head(link,
                                                  allow_redirects=True).url
                     matcher = SequenceMatcher(

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -98,13 +98,15 @@ class InvalidLinkBearTest(unittest.TestCase):
 
         # Not a link
         http://not a link dot com
+
+        # Redirect
+        http://httpbin.org/status/301
+        http://httpbin.org/status/302
         """.splitlines()
 
         self.assertResult(valid_file=valid_file)
 
         invalid_file = """http://coalaisthebest.com/
-        http://httpbin.org/status/301  # Redirect
-        http://httpbin.org/status/302  # Redirect
         http://httpbin.org/status/404
         http://httpbin.org/status/410
         http://httpbin.org/status/500
@@ -130,7 +132,8 @@ class InvalidLinkBearTest(unittest.TestCase):
         """.splitlines()
 
         self.assertResult(valid_file=long_url_redirect,
-                          invalid_file=short_url_redirect)
+                          invalid_file=short_url_redirect,
+                          settings={'follow_redirects': 'yeah'})
 
     def test_ignore_regex(self):
 


### PR DESCRIPTION
A lot of people aren't using this bear because they don't want redirects
to be corrected. We should build a better heuristic until we make that
functionality default and we need that setting anyway.

Closes https://github.com/coala-analyzer/coala-bears/issues/528