### PR TITLE
AnnotationBear: Yield Result for no coalang

### DIFF
--- a/bears/general/AnnotationBear.py
+++ b/bears/general/AnnotationBear.py
@@ -26,7 +26,14 @@ class AnnotationBear(LocalBear):
                                 a tuple of SourceRanges of comments
                                 respectively.
         """
-        lang_dict = LanguageDefinition(language, coalang_dir=coalang_dir)
+        try:
+            lang_dict = LanguageDefinition(language, coalang_dir=coalang_dir)
+        except FileNotFoundError:
+            content = ("coalang specification for " + language +
+                       " not found.")
+            yield HiddenResult(self, content)
+            return
+
         string_delimiters = dict(lang_dict["string_delimiters"])
         multiline_string_delimiters = dict(
             lang_dict["multiline_string_delimiters"])

--- a/tests/general/AnnotationBearTest.py
+++ b/tests/general/AnnotationBearTest.py
@@ -132,3 +132,11 @@ class AnnotationBearTest(unittest.TestCase):
         with execute_bear(uut, "F", text) as result:
             self.assertNotEqual(result[0].contents['strings'], ())
             self.assertNotEqual(result[0].contents['comments'], ())
+
+    def test_no_coalang(self):
+        self.section1.append(Setting('language', 'Valyrian'))
+        text = ["Valar Morghulis"]
+        uut = AnnotationBear(self.section1, Queue())
+        with execute_bear(uut, "F", text) as result:
+            self.assertEqual(result[0].contents,
+                             "coalang specification for Valyrian not found.")


### PR DESCRIPTION
Earlier the bear used to error out, but handling a
Result is way easier