### PR TITLE
requirements.txt: Add pyflakes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ nltk==3.2.*
 appdirs==1.*
 pyyaml==3.*
 vulture==0.10.*
+pyflakes==1.2.*  # Although we don't need this directly, solves a dep conflict


### PR DESCRIPTION
Although we don't need t directly, this release breaks coala. This is a
hotfix and should be reverted when our dependencies have adapted.
Appropriate issues are being filed as I write this.