### PR TITLE
KeywordBear: Rename arguments

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -35,5 +35,5 @@ max_lines_per_file = 1000
 enabled = False
 bears = KeywordBear
 
-ci_keywords = \#TODO, \# TODO, \#FIXME, \# FIXME
+ci_keywords, keywords_case_insensitive = \#TODO, \# TODO, \#FIXME, \# FIXME
 cs_keywords =

--- a/bears/general/KeywordBear.py
+++ b/bears/general/KeywordBear.py
@@ -1,3 +1,4 @@
+from coalib.bearlib import deprecate_settings
 from coalib.bears.LocalBear import LocalBear
 from coalib.results.Result import RESULT_SEVERITY, Result
 
@@ -9,32 +10,34 @@ class KeywordBear(LocalBear):
     LICENSE = 'AGPL-3.0'
     CAN_DETECT = {'Documentation'}
 
+    @deprecate_settings(keywords_case_sensitive='cs_keywords')
     def run(self,
             filename,
             file,
-            cs_keywords: list,
-            ci_keywords: list):
+            keywords_case_insensitive: list,
+            keywords_case_sensitive: list=()):
         '''
         Checks the code files for given keywords.
 
-        :param cs_keywords: A list of keywords to search for (case sensitive).
-                            Usual examples are TODO and FIXME.
-        :param ci_keywords: A list of keywords to search for (case
-                            insensitive).
+        :param keywords_case_insensitive:
+            A list of keywords to search for (case insensitive).
+            Usual examples are TODO and FIXME.
+        :param keywords_case_sensitive:
+            A list of keywords to search for (case sensitive).
         '''
         results = list()
 
-        for i in range(len(ci_keywords)):
-            ci_keywords[i] = ci_keywords[i].lower()
+        for i in range(len(keywords_case_insensitive)):
+            keywords_case_insensitive[i] = keywords_case_insensitive[i].lower()
 
         for line_number, line in enumerate(file):
-            for keyword in cs_keywords:
+            for keyword in keywords_case_sensitive:
                 results += self.check_line_for_keyword(line,
                                                        filename,
                                                        line_number,
                                                        keyword)
 
-            for keyword in ci_keywords:
+            for keyword in keywords_case_insensitive:
                 results += self.check_line_for_keyword(line.lower(),
                                                        filename,
                                                        line_number,

--- a/tests/general/KeywordBearTest.py
+++ b/tests/general/KeywordBearTest.py
@@ -8,12 +8,14 @@ error fixme
 """
 
 
-KeywordBearTest = verify_local_bear(KeywordBear,
-                                    valid_files=(test_file,),
-                                    invalid_files=("test line FIXME",
-                                                   "test line todo",
-                                                   "test line warNING",
-                                                   "test line ERROR"),
-                                    settings={
-                                       "cs_keywords": "FIXME, ERROR",
-                                       "ci_keywords": "todo, warning"})
+KeywordBearTest = verify_local_bear(
+    KeywordBear,
+    valid_files=(test_file,),
+    invalid_files=("test line FIXME",
+                   "test line todo",
+                   "test line warNING",
+                   "test line ERROR"),
+    settings={
+       "keywords_case_sensitive": "FIXME, ERROR",
+       "keywords_case_insensitive": "todo, warning"
+    })


### PR DESCRIPTION
Rename of weirdly named settings: ci_keywords to keywords_case_insensitive
and cs_keywords to keywords_case_sensitive.

Closes https://github.com/coala-analyzer/coala-bears/issues/756