### PR TITLE
ESLintBear: Show errors shown in stderr

### DIFF
--- a/bears/js/ESLintBear.py
+++ b/bears/js/ESLintBear.py
@@ -8,7 +8,8 @@ from coalib.results.Result import Result
 
 
 @linter(executable='eslint',
-        use_stdin=True)
+        use_stdin=True,
+        use_stderr=True)
 class ESLintBear:
     """
     Check JavaScript and JSX code for style issues and semantic errors.
@@ -48,10 +49,15 @@ class ESLintBear:
         return '{"extends": "eslint:recommended"}'
 
     def process_output(self, output, filename, file):
-        if not file or not output:
+        if output[1]:
+            self.warn("While running {0}, some issues were found:"
+                      .format(self.__class__.__name__))
+            self.warn(output[1])
+
+        if not file or not output[0]:
             return
 
-        output = json.loads(output)
+        output = json.loads(output[0])
         lines = "".join(file)
 
         assert len(output) == 1


### PR DESCRIPTION
In some cases, eslint fails. Because of this, the user can't see any
results, nor does the user see any warning that it failed. We now show
the stderr to the user as a WARNING.

Fixes https://github.com/coala-analyzer/coala-bears/issues/730